### PR TITLE
remove external eks-to-helm action and setup kubectl ourselves

### DIFF
--- a/.github/workflows/chartpress.yaml
+++ b/.github/workflows/chartpress.yaml
@@ -135,5 +135,4 @@ jobs:
 
     - name: Production - helm deploy
       if: github.ref == 'refs/heads/main'
-      uses: koslibpro/helm-eks-action@master
       run: helm upgrade production --wait ohm/ -f values.production.yaml -f ohm/values.yaml


### PR DESCRIPTION
This avoids having to pass in a KUBECONFIG secret, we just generate the kube config by logging into AWS as part of the CI action.

@geohacker i'll need to merge this to staging to test.