### PR TITLE
Tegola debug flag

### DIFF
--- a/images/tiler-server/start.sh
+++ b/images/tiler-server/start.sh
@@ -3,6 +3,6 @@ flag=true
 while "$flag" = true; do
   pg_isready -h $POSTGRES_HOST -p 5432 >/dev/null 2>&2 || continue
   flag=false
-  # TEGOLA_SQL_DEBUG=EXECUTE_SQL 
+  export TEGOLA_SQL_DEBUG=LAYER_SQL:EXECUTE_SQL
   tegola serve --config=/opt/tegola_config/config.toml
 done


### PR DESCRIPTION
Add tegola debug flag so we can see SQL per tile request. This is essential to identify some of the recent tile issues. cc @danrademacher 