### PR TITLE
Rebuild iD with empty commit

### DIFF
--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -117,9 +117,9 @@ RUN git clone https://github.com/OpenHistoricalMap/ohm-website.git $workdir
 WORKDIR $workdir
 # change the echo here with a reason for changing the commithash
 
-RUN echo 'try mimemagic update'
+RUN echo 'empty commit to force iD to rebuild from staging'
 RUN git fetch
-RUN git checkout 644df04f7eee0ef401f4f6f1a09674d9f0ae4d58
+RUN git checkout 23691dcf173a196a728ec031b2058f1180154b27
 
 # Install the javascript runtime required by the `execjs` gem in
 RUN apt-get install -y libv8-dev


### PR DESCRIPTION
not clear how else to get this to pull new dist artifacts from iD pulled through, since there's no change in ohm-website but we need it to fetch new iD code.