### PR TITLE
Fixing tiler cache  for s3

### DIFF
--- a/images/tiler-server/seed-by-diffs.sh
+++ b/images/tiler-server/seed-by-diffs.sh
@@ -35,10 +35,11 @@ for f in $imp_list; do
     while IFS= read -r tile
     do
         bounds="$(python tile2bounds.py $tile)"
+        minZoom=${tile%%/*}
         set -x;
         tegola cache purge \
             --config=/opt/tegola_config/config.toml \
-            --min-zoom=0 \
+            --min-zoom=$minZoom \
             --max-zoom=20 \
             --overwrite=true \
             --bounds=$bounds \


### PR DESCRIPTION
- Add overwrite options to remove tiles from s3.
- Set min zoom to avoid tiler-cache removing min zooms e.g `1,2,3,4`  from s3. 
@geohacker @batpad 