### PR TITLE
Avoid printing  tiler cache logs

### DIFF
--- a/images/tiler-server/seed-by-diffs.sh
+++ b/images/tiler-server/seed-by-diffs.sh
@@ -29,43 +29,19 @@ if [ -f $queued_jobs ]; then
 fi
 
 for f in $imp_list; do
-    echo "Purge tiles from...$f"
-    set -x
-    tegola cache purge tile-list $f \
+    # echo "Purge tiles from...$f"
+    ( set -x ; tegola cache purge tile-list $f \
         --config=/opt/tegola_config/config.toml \
         --format="/zxy" \
         --min-zoom=0 \
         --max-zoom=20 \
-        --overwrite=true &
-    set +x
+        --overwrite=true 1> /dev/null & )
     sleep 10
-    # while IFS= read -r tile; do
-    #     bounds="$(python3 tile2bounds.py $tile)"
-    #     # Get tiles values
-    #     arraytile=($(echo "$tile" | tr '/' '\n'))
-    #     zoom=${arraytile[0]}
-    #     x=${arraytile[1]}
-    #     y=${arraytile[2]}
-    #     set -x
-    #     tegola cache purge \
-    #         --config=/opt/tegola_config/config.toml \
-    #         --min-zoom=$zoom \
-    #         --max-zoom=20 \
-    #         --overwrite=true \
-    #         --bounds=$bounds \
-    #         tile-name=$tile
-    #     err=$?
-    #     set +x
-    #     if [[ $err != "0" ]]; then
-    #         echo "tegola exited with error code $err"
-    #         exit
-    #     fi
-    # done <"$f"
     echo "$f" >>$completed_jobs
     mv $f $completed_dir
 done
 
 if [ -f $queued_jobs ]; then
-    echo "finished seeding"
+    # Completed queued jobs
     rm $queued_jobs
 fi


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/333#issuecomment-1055127984

We figured out that Tiler cache cleaner is creating a tons of logs that are storing in New relic, We are making some changes to avoid printing such logs in order to reduce  the workload in New relic. e.g of the logs👇 
<img width="913" alt="image" src="https://user-images.githubusercontent.com/1152236/156399316-b8609e05-3c87-4611-8486-de77d8e7a8b9.png">
cc. @batpad @danrademacher
