### PR TITLE
add tm container with ohm fork

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -11,3 +11,5 @@ charts:
         valuesPath: osm-seed.tilerDb.image
       tiler-server:
         valuesPath: osm-seed.tilerServer.image
+      tasking-manager-api:
+        valuesPath: osm-seed.tmApi.image

--- a/images/tasking-manager-api/Dockerfile
+++ b/images/tasking-manager-api/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.7-alpine
+
+RUN apk update && \
+    apk add git
+
+ENV workdir /usr/src/app
+
+RUN git clone https://github.com/OpenHistoricalMap/tasking-manager.git $workdir
+# Commits on 25 April, 2022
+RUN cd $workdir && git checkout -f 7e98aa805715b76aa7b1febdb6dd0da6a2b19b5b
+WORKDIR $workdir
+
+# Setup backend dependencies
+RUN apk update && \
+    apk add \
+        gcc \
+        g++ \
+        make \
+        musl-dev \
+        libffi-dev \
+        python3-dev \
+        postgresql-dev \
+        geos-dev \
+        proj-util \
+        proj-dev
+
+RUN pip install -r requirements.txt
+RUN pip install apscheduler==3.7.0
+
+## INITIALIZATION
+EXPOSE 5000
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "--worker-class", "gevent", "--workers", "3", \
+    "--threads", "3", "--timeout", "179", "manage:application", "&"]

--- a/images/tasking-manager-api/README.md
+++ b/images/tasking-manager-api/README.md
@@ -1,0 +1,13 @@
+# Docker setup for Tasking Manager 4 API
+
+### Configuration
+1. Copy `./envs/.env.tasking-manager.example` to `./envs/.env.tasking-manager`
+2. This setup doesn't come with a database container, so you'd have to standup your own. For now.
+3. Supply appropirate environment variables, particularly OAuth keys and database credentials
+
+
+### Build and run
+* `cd tasking-manager-api`
+* `docker build -t osmseed-tasking-manager-api:v1 .`
+* `docker run --env-file ../.env-tasking-manager -p "5000:5000" -t osmseed-tasking-manager-api:v1`
+

--- a/ohm/values.yaml
+++ b/ohm/values.yaml
@@ -15,3 +15,7 @@ osm-seed:
     image:
       name: chartpress_replace_me
       tag: chartpress_replace_me
+  tmApi:
+    image:
+      name: chartpress_replace_me
+      tag: chartpress_replace_me


### PR DESCRIPTION
Adds the OHM fork for Tasking Manager to the ohm-deploy process. This should now build and deploy Tasking Manager from our fork.

@Rub21 does this look right?

cc @willemarcel 