### PR TITLE
update osm-seed version (use version from fix/osm-env-names branch)

### DIFF
--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
  - name: osm-seed
-   version: '0.1.0-n701.hfb158d1'
+   version: '0.1.0-n698.h385315f'
    repository: https://devseed.com/osm-seed-chart/


### PR DESCRIPTION
@Rub21 I rebased your changes on `osm-seed` develop fixing the TM build, and published a new version of `osm-seed` from this branch: https://github.com/developmentseed/osm-seed/pull/254

That just includes the env var changes that should make `iD` and `memcached` work again on staging. If you need to make any further changes on `osm-seed`, could you branch off the `fix/osm-env-names` branch in `osm-seed`?