### PR TITLE
use updated version of osm-seed setting connection timeout

### DIFF
--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
  - name: osm-seed
-   version: '0.1.0-n698.h385315f'
+   version: '0.1.0-n699.h0a6dc24'
    repository: https://devseed.com/osm-seed-chart/


### PR DESCRIPTION
Attempting to fix https://github.com/OpenHistoricalMap/issues/issues/420

Sets the idle connection timeout value on the load balancer: https://github.com/developmentseed/osm-seed/pull/254/commits/0a6dc249eb750b9ab522389d9107eb8bde5d5a9d

It's a bit of a shot in the dark, but maybe worth trying.