### PR TITLE
Update Postgres list source 

### DIFF
--- a/images/db/Dockerfile
+++ b/images/db/Dockerfile
@@ -1,11 +1,13 @@
 FROM postgres:11
-RUN apt-get update \
-    && apt-get install -y \
+RUN rm /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update && apt-get -y install apt-transport-https
+RUN echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main 11" >/etc/apt/sources.list.d/pgdg.list
+RUN apt-get update && apt-get install -y \
     postgresql-server-dev-11 \
     make \
     build-essential \
-    postgresql-11-postgis-2.5 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    postgresql-11-postgis-2.5 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ADD functions/functions.sql /usr/local/share/osm-db-functions.sql
 ADD docker_postgres.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
from: https://github.com/OpenHistoricalMap/issues/issues/484

According to the documentation: https://www.postgresql.org/message-id/Y2kmqL%2BpCuSZiQBV%40msg.df7cb.de



> Re: To PostgreSQL in Debian
> With the end of LTS support for Debian stretch, we are no longer
> supporting stretch on [apt.postgresql.org](http://apt.postgresql.org/).
> 
> https://wiki.debian.org/LTS/
> 
> stretch-pgdg has been copied to [apt-archive.postgresql.org](http://apt-archive.postgresql.org/) and will be
> removed from [apt.postgresql.org](http://apt.postgresql.org/) at the end of October 2022.
> The files have been removed now.
> If you still need stretch, the files are on apt-archive now:

I have updated the  source list.

cc. @danrademacher @batpad 

