### PR TITLE
iD oauth2

### DIFF
--- a/.github/workflows/chartpress.yaml
+++ b/.github/workflows/chartpress.yaml
@@ -46,6 +46,7 @@ jobs:
         STAGING_DB_USER: ${{ secrets.STAGING_DB_USER }}
         STAGING_DOMAIN_NAME: ${{ secrets.STAGING_DOMAIN_NAME }}
         STAGING_ID_KEY: ${{ secrets.STAGING_ID_KEY }}
+        STAGING_ID_APPLICATION: ${{ secrets.STAGING_ID_APPLICATION }}
         STAGING_OAUTH_CLIENT_ID: ${{ secrets.STAGING_OAUTH_CLIENT_ID }}
         STAGING_OAUTH_KEY: ${{ secrets.STAGING_OAUTH_KEY }}
         STAGING_S3_BUCKET: ${{ secrets.STAGING_S3_BUCKET }}

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -29,7 +29,7 @@ sed -i -e 's/smtp_port: 25/smtp_port: '$MAILER_PORT'/g' $workdir/config/settings
 
 
 #### SET UP ID KEY
-sed -i -e 's/#id_key: ""/id_key: "'$OPENSTREETMAP_id_key'"/g' $workdir/config/settings.yml
+sed -i -e 's/#id_application: ""/id_application: "'$OPENSTREETMAP_id_application'"/g' $workdir/config/settings.yml
 
 ### SET UP OAUTH ID AND KEY
 sed -i -e 's/OAUTH_CLIENT_ID/'$OAUTH_CLIENT_ID'/g' $workdir/config/settings.yml

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -110,6 +110,7 @@ osm-seed:
         MAILER_USERNAME: {{MAILER_USERNAME}}
         MAILER_PASSWORD: {{MAILER_PASSWORD}}
         OSM_id_key: {{STAGING_ID_KEY}}
+        OSM_id_application: {{STAGING_ID_APPLICATION}}
         OAUTH_CLIENT_ID: {{STAGING_OAUTH_CLIENT_ID}}
         OAUTH_KEY: {{STAGING_OAUTH_KEY}}
         MAILER_FROM: no-reply@openhistoricalmap.org


### PR DESCRIPTION
Add settings for iD oauth2 support. With the new updates, we need to fix the settings.yml to use id_application instead of id_key. These are the steps:
1. Login to staging.openhistoricalmap.org
2. Create an iD Staging Application OAuth2, with https://staging.openhistoricalmap.org as call back
3. Create a Github secret called STAGING_ID_APPLICATION and paste the client id there
4. Edit workflows/chartpress.yml and read the secret there
5. Edit values.staging.template.yaml and pass the id_application to the env of the web pod
6. Edit settings.yml and add id_application there, remove id_key
7. Edit start.sh and replace the value of id_application from the value in the env

Fixes https://github.com/OpenHistoricalMap/issues/issues/489
cc @danrademacher @batpad @Rub21 