### PR TITLE
Update replication values for production tiler

### DIFF
--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -332,10 +332,10 @@ osm-seed:
       label_value: tiler
     env:
       TILER_IMPORT_FROM: osm
-      TILER_IMPORT_PBF_URL: http://planet.openhistoricalmap.org.s3.amazonaws.com/planet/planet-220908_0000.osm.pbf
+      TILER_IMPORT_PBF_URL: http://planet.openhistoricalmap.org.s3.amazonaws.com/planet/planet-230109_0000.osm.pbf
       REPLICATION_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/replication/minute/
       OVERWRITE_STATE: true
-      SEQUENCE_NUMBER: 838000
+      SEQUENCE_NUMBER: 929000
     persistenceDisk:
       enabled: true
       accessMode: ReadWriteOnce


### PR DESCRIPTION
Updating values for tiler, using this changes, we are going to reinsert the data into a clean tiler database.

The issue happens  because, when we updated the changes 3 days ago, the data insertion was not restarted for tiler, there were some changes in the tiler that needs re-insert data  into a new tiler DB : e.g: https://github.com/OpenHistoricalMap/issues/issues/463 , and some other changes that there is not necessary to re-insert the data. e.g: https://github.com/OpenHistoricalMap/issues/issues/111
 
cc. @danrademacher @batpad 

