### PR TITLE
Redirect   domain to www. in web container

### DIFF
--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -9,7 +9,9 @@
     RewriteRule .* https://www.%{HTTP:Host}%{REQUEST_URI} [L,R=permanent]
     # Avoid redirect localhost
     RewriteCond %{HTTP_HOST} !=localhost
-    RewriteRule ^ https://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+    RewriteCond %{HTTPS} !=on
+    RewriteCond %{HTTP_HOST} !^www\..+$ [NC]
+    RewriteRule ^ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
     # Relax Apache security settings
     <Directory /var/www/public>

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -6,10 +6,14 @@
 
     RewriteEngine On
     RewriteCond %{HTTP:X-Forwarded-Proto} =http
-    RewriteRule .* https://%{HTTP:Host}%{REQUEST_URI} [L,R=permanent]
+    RewriteRule .* https://www.%{HTTP:Host}%{REQUEST_URI} [L,R=permanent]
+    # Avoid redirect localhost
+    RewriteCond %{HTTP_HOST} !=localhost
+    RewriteRule ^ https://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
     # Relax Apache security settings
     <Directory /var/www/public>
+      AllowOverride None
       Allow from all
       Options -MultiViews
     </Directory>

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -6,12 +6,15 @@
 
     RewriteEngine On
     RewriteCond %{HTTP:X-Forwarded-Proto} =http
-    RewriteRule .* https://www.%{HTTP:Host}%{REQUEST_URI} [L,R=permanent]
-    # Avoid redirect localhost
+    #  Development mode in case domain is localhost
+    # Rewrite to HTTPS
     RewriteCond %{HTTP_HOST} !=localhost
-    RewriteCond %{HTTPS} !=on
-    RewriteCond %{HTTP_HOST} !^www\..+$ [NC]
-    RewriteRule ^ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+    RewriteCond %{HTTPS} off
+    RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+    # Rewrite to www. [NC] is a case-insensitive match
+    RewriteCond %{HTTP_HOST} !=localhost
+    RewriteCond %{HTTP_HOST} !^www\. [NC]
+    RewriteRule .* https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
     # Relax Apache security settings
     <Directory /var/www/public>

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
  - name: osm-seed
-   version: '0.1.0-n751.hc6b5a03'
+   version: '0.1.0-n753.haf62186'
    repository: https://devseed.com/osm-seed-chart/


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/508

@batpad  here is the configuration to redirect to `www` URL ,  it works fine,  but in staging it is showing  a non secure page, do you have any idea about that? 
![image](https://user-images.githubusercontent.com/1152236/216171724-c47f39a8-5974-4b20-acb3-dfeb8fa50235.png)

```
wget staging.openhistoricalmap.org
--2023-02-01 16:52:58--  http://staging.openhistoricalmap.org/
Resolving staging.openhistoricalmap.org (staging.openhistoricalmap.org)... 54.84.95.254, 54.205.101.229
Connecting to staging.openhistoricalmap.org (staging.openhistoricalmap.org)|54.84.95.254|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.staging.openhistoricalmap.org/ [following]
--2023-02-01 16:52:59--  https://www.staging.openhistoricalmap.org/
Resolving www.staging.openhistoricalmap.org (www.staging.openhistoricalmap.org)... 54.84.95.254, 54.205.101.229
Connecting to www.staging.openhistoricalmap.org (www.staging.openhistoricalmap.org)|54.84.95.254|:443... connected.
ERROR: no certificate subject alternative name matches
	requested host name ‘www.staging.openhistoricalmap.org’.
To connect to www.staging.openhistoricalmap.org insecurely, use `--no-check-certificate'.
```
cc.  @danrademacher 