### PR TITLE
Avoid pushing files in s3 if build fails for static pages

### DIFF
--- a/.github/workflows/frontend-nominatim.yaml
+++ b/.github/workflows/frontend-nominatim.yaml
@@ -73,6 +73,7 @@ jobs:
           pip install awscli
 
       - name: Push data to s3 and clean cloudfront cache
+        if: ${{ success() }}
         run: |
           aws s3 sync dist/ s3://${NOMINATIM_BUCKET}/
           aws cloudfront create-invalidation --distribution-id=${CLOUDFRONT_DISTRIBUTION_ID} --paths=/

--- a/.github/workflows/frontend-overpass.yaml
+++ b/.github/workflows/frontend-overpass.yaml
@@ -63,6 +63,7 @@ jobs:
           pip install awscli
 
       - name: Push data to s3 and clean cloudfront cache
+        if: ${{ success() }}
         run: |
           aws s3 sync build/ s3://${OVERPASS_BUCKET}/
           aws cloudfront create-invalidation --distribution-id=${CLOUDFRONT_DISTRIBUTION_ID} --paths=/

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -49,7 +49,7 @@ RUN npm install -g svgo
 RUN rm -rf $workdir/html
 
 RUN echo "Updates: website(staging-1cc43f1)-03/03/2023, iD(staging-9aaf001)-03/03/2023"
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=1cc43f18696333a225b0ae2fd15fb11cc3e8ba74
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=b0095fae7eda5cc078ebed0b64a04863fc267b3c
 RUN git clone -b staging https://github.com/OpenHistoricalMap/ohm-website.git $workdir
 WORKDIR $workdir
 RUN git checkout $OPENHISTORICALMAP_WEBSITE_GITSHA

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -48,7 +48,7 @@ RUN npm install -g svgo
 # Install openstreetmap-website
 RUN rm -rf $workdir/html
 
-RUN echo "Updates: website(staging-1cc43f1)-01/03/2023, iD(staging-9aaf001)-03/03/2023"
+RUN echo "Updates: website(staging-1cc43f1)-03/03/2023, iD(staging-9aaf001)-03/03/2023"
 ENV OPENHISTORICALMAP_WEBSITE_GITSHA=1cc43f18696333a225b0ae2fd15fb11cc3e8ba74
 RUN git clone -b staging https://github.com/OpenHistoricalMap/ohm-website.git $workdir
 WORKDIR $workdir

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -48,7 +48,7 @@ RUN npm install -g svgo
 # Install openstreetmap-website
 RUN rm -rf $workdir/html
 
-# GITSHA value at Mar 1, 2023
+RUN echo "Updates: website(staging)-01/03/2023, iD(staging)-02/03/2023"
 ENV OPENHISTORICALMAP_WEBSITE_GITSHA=1cc43f18696333a225b0ae2fd15fb11cc3e8ba74
 RUN git clone -b staging https://github.com/OpenHistoricalMap/ohm-website.git $workdir
 WORKDIR $workdir

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -48,7 +48,7 @@ RUN npm install -g svgo
 # Install openstreetmap-website
 RUN rm -rf $workdir/html
 
-RUN echo "Updates: website(staging)-01/03/2023, iD(staging)-02/03/2023"
+RUN echo "Updates: website(staging-1cc43f1)-01/03/2023, iD(staging-9aaf001)-03/03/2023"
 ENV OPENHISTORICALMAP_WEBSITE_GITSHA=1cc43f18696333a225b0ae2fd15fb11cc3e8ba74
 RUN git clone -b staging https://github.com/OpenHistoricalMap/ohm-website.git $workdir
 WORKDIR $workdir


### PR DESCRIPTION
I have added some restrictions in github action config, to evade pushing static files in s3 in case building fails.
cc. @danrademacher @batpad 