### PR TITLE
Production installation in Kubernetes 1.27

### DIFF
--- a/.github/workflows/chartpress.yaml
+++ b/.github/workflows/chartpress.yaml
@@ -160,8 +160,8 @@ jobs:
 
     - name: Staging - helm deploy
       if: github.ref == 'refs/heads/staging'
-      run: helm upgrade staging --wait ohm/ -f values.staging.yaml -f ohm/values.yaml
+      run: helm upgrade --install staging --wait ohm/ -f values.staging.yaml -f ohm/values.yaml
 
     - name: Production - helm deploy
       if: github.ref == 'refs/heads/main'
-      run: helm upgrade production --wait ohm/ -f values.production.yaml -f ohm/values.yaml
+      run: helm upgrade --install production --wait ohm/ -f values.production.yaml -f ohm/values.yaml

--- a/.github/workflows/chartpress.yaml
+++ b/.github/workflows/chartpress.yaml
@@ -152,7 +152,7 @@ jobs:
 
     - name: Update kube-config prod
       if: github.ref == 'refs/heads/main'
-      run: aws eks --region us-east-1 update-kubeconfig --name osmseed-production
+      run: aws eks --region us-east-1 update-kubeconfig --name osmseed-production-v2
 
     - name: Install helm dependencies for
       if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ tiler-imposm-data
 tiler-imposm
 images/data/
 data/
+images/.env
+images/tiler.yml
+values.dev.yaml

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
- - name: osm-seed
-   version: '1.0.0-dev.h51a2eed'
-   repository: https://devseed.com/osm-seed-chart/
+- name: osm-seed
+  version: '0.1.0-n764.he48f5aa'
+  repository: https://devseed.com/osm-seed-chart/

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: osm-seed
-  version: '0.1.0-n766.hdeb9898'
+  version: '0.1.0-n768.h0ae6329'
   repository: https://devseed.com/osm-seed-chart/

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: osm-seed
-  version: '0.1.0-n764.he48f5aa'
+  version: '0.1.0-n766.hdeb9898'
   repository: https://devseed.com/osm-seed-chart/

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -110,15 +110,15 @@ osm-seed:
     resources:
       enabled: true
       requests:
-        memory: "500Mi"
-        cpu: "0.5"
+        memory: "8GB"
+        cpu: "2"
       limits:
-        memory: "1Gi"
-        cpu: "1"
+        memory: "8GB"
+        cpu: "2"
     autoscaling:
       enabled: true
       minReplicas: 2
-      maxReplicas: 15
+      maxReplicas: 10
       cpuUtilization: 80
   # ====================================================================================================
   # Variables for memcached. Memcached is used to store session cookies

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -110,10 +110,10 @@ osm-seed:
     resources:
       enabled: true
       requests:
-        memory: "8GB"
+        memory: "8Gi"
         cpu: "2"
       limits:
-        memory: "8GB"
+        memory: "8Gi"
         cpu: "2"
     autoscaling:
       enabled: true

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -110,15 +110,15 @@ osm-seed:
     resources:
       enabled: true
       requests:
-        memory: "8Gi"
-        cpu: "2"
+        memory: "500Mi"
+        cpu: "0.5"
       limits:
-        memory: "8Gi"
-        cpu: "2"
+        memory: "1Gi"
+        cpu: "1"
     autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 15
       cpuUtilization: 80
   # ====================================================================================================
   # Variables for memcached. Memcached is used to store session cookies
@@ -147,7 +147,7 @@ osm-seed:
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
-      label_value: web
+      label_value: job
     env:
       OVERWRITE_PLANET_FILE: false
     resources:
@@ -168,7 +168,7 @@ osm-seed:
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
-      label_value: web
+      label_value: job
     env:
       OVERWRITE_FHISTORY_FILE: false
     resources:
@@ -267,7 +267,7 @@ osm-seed:
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
-      label_value: web
+      label_value: job
     env:
       DB_ACTION: backup
       RESTORE_URL_FILE: https://osmseed-production-db.s3.us-east-1.amazonaws.com/database/osmseed-db-220803_1606.sql.gz?response-content-disposition=inline&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDcaCXNhLWVhc3QtMSJIMEYCIQC6oYShK01LFCHNNOP0%2Bch5uKeAcpSmfRLxnaaygUYd5QIhAKt0OtxclFyJrX1qqdOfOgcylfVGBi%2FizMIIISenxD%2FbKoQDCJD%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQAhoMNjE4MzgwMjQyMjQ3IgzdtXrtIBspySZIJ0Yq2AJ0RovZahua04PQ%2FBWVGLhmQPxRiN6Pe5evt2FUuVFdrSMGaqfxo3YAGTezOmviYoqtrHf7NZHRcHQx9RTB4Nk2rmeZfQ9xepB7semK0G3VbzDqsVTzglFDxk52xqpESYYf6vVbORyBDJvjvlCjUAXLH1PqOlj%2FFDd5A3UK3%2FCSJc9JfYh1LVkz4md6ug3mh0KYpUL0%2FipBVpQTcN0PCkVJTTPWOBXmn9qnYMUJg2LNRVMkgIr7AA2MmmSVzPhj%2FfnaHIXCCbHlJ5RA9IgpftC%2FEvTrP2cvgcV03YOWSq9sSMg%2B%2B0xDWn7stI9PsKoakHX%2B%2BtsxHimJ4uGTY8I7DsV915Kzgx1aRlJ5MYjOtbSuMOfhZP6FSwLGRTPw7qvS0kLFKHAwCYLsd7GF6%2FHadTbLSJ0Zx0EqPYVjyIKfwZ5fu204xUkGhCqBlHuQBQhoG%2FMxcnYf53NoSTChm6qXBjqyAkr7doHwSC9HTJYlIq7gixhkZ29BfaHp8jq0gIBW7aAEC3idFdN2ZQd9pHQAgN4fKYrOmC%2Bbf9njZH91%2BEvzwpEHXyho8E8lPSQJGJZnAquRzJkzJ23%2F4zF51Rf2WMSpmYMHyWXodLLP4yYj%2Bgk%2Bg%2FbUsDYhkq4%2B%2F5%2Bf7YLCmvi%2BdO%2B5GEZEa%2B1iPghxd%2BH8eQk9jUlebsI3fh01f%2Bv6TbzgGieM7eqXYeH0JTZDZGEJlPdbUzMHKcj6G6kuTX4nvD9YDPQzUYAoVwu2gwjvrjaHRaK8NKMlEC7JCIlsWrVzjVR%2FtXlBybrZ5rSdZNeTIDDof5lS8O%2F9qqyhTel4pObDPNosj6jCOVPe3geM5ZNZVbL4ATUdJ5oU3BcTm%2FMcerATv%2FysoVrskKNuDMjHoT3fkA%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220803T172639Z&X-Amz-SignedHeaders=host&X-Amz-Expires=2400&X-Amz-Credential=ASIAY76SVVVDSEAYVNUG%2F20220803%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=6ed260d9d775bbc6b0d4f5e08575552270c970a81afa2254f87b62c3b97730c2
@@ -291,7 +291,7 @@ osm-seed:
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
-      label_value: tiler
+      label_value: web
     env:
       POSTGRES_HOST: {{PRODUCTION_TILER_DB_HOST}}
       POSTGRES_DB: {{PRODUCTION_TILER_DB}}
@@ -329,10 +329,10 @@ osm-seed:
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
-      label_value: tiler
+      label_value: web
     env:
       TILER_IMPORT_FROM: osm
-      TILER_IMPORT_PBF_URL: http://planet.openhistoricalmap.org.s3.amazonaws.com/planet/planet-230109_0000.osm.pbf
+      TILER_IMPORT_PBF_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-230727_1030.osm.pbf
       REPLICATION_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/replication/minute/
       OVERWRITE_STATE: true
       SEQUENCE_NUMBER: 929000
@@ -360,7 +360,7 @@ osm-seed:
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
-      label_value: tiler
+      label_value: web
     replicaCount: 2
     commad: './start.sh'
     serviceAnnotations:
@@ -386,12 +386,16 @@ osm-seed:
     resources:
       enabled: true
       requests:
-        memory: "8Gi"
-        cpu: "4"
+        memory: "2Gi"
+        cpu: "1"
       limits:
-        memory: "8Gi"
-        cpu: "4"
-  
+        memory: "10Gi"
+        cpu: "2"
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 2
+      cpuUtilization: 60  
   # ====================================================================================================
   # Variables for tiler-server cache cleaner, only avaliable in case the TILER_CACHE_TYPE = s3  
   # ====================================================================================================
@@ -400,18 +404,22 @@ osm-seed:
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
-      label_value: tiler
+      label_value: web
     replicaCount: 1
     command: './cache_cleaner.sh'
     resources:
-      enabled: false
+      enabled: true
       requests:
-        memory: '1Gi'
-        cpu: '2'
+        memory: "8Gi"
+        cpu: "1"
       limits:
-        memory: '2Gi'
-        cpu: '2'
-
+        memory: "10Gi"
+        cpu: "2"
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 2
+      cpuUtilization: 60
   # ====================================================================================================
   # Variables for tiler-visor
   # ====================================================================================================
@@ -499,7 +507,7 @@ osm-seed:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
     replicaCount: 1
     env:
-      PBF_URL: http://planet.openhistoricalmap.org.s3.amazonaws.com/planet/planet-230126_0000.osm.pbf
+      PBF_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-230727_1030.osm.pbf
       REPLICATION_URL: http://planet.openhistoricalmap.org.s3.amazonaws.com/replication/minute
       REPLICATION_UPDATE_INTERVAL: 60
       REPLICATION_RECHECK_INTERVAL: 30
@@ -537,7 +545,9 @@ osm-seed:
       GCP_gcePersistentDisk_pdName: osmseed-disk-nominatim_db-v1
       GCP_gcePersistentDisk_size: 50Gi
     nodeSelector:
-      enabled: false
+      enabled: true
+      label_key: nodegroup_type
+      label_value: web
 
 # ====================================================================================================
 # Variables for overpass-api
@@ -597,7 +607,9 @@ osm-seed:
         memory: '2Gi'
         cpu: '2'
     nodeSelector:
-      enabled: false
+      enabled: true
+      label_key: nodegroup_type
+      label_value: web
 # ====================================================================================================
 # Variables for osm-simple-metrics
 # ====================================================================================================
@@ -613,4 +625,6 @@ osm-seed:
         memory: '2Gi'
         cpu: '2'
     nodeSelector:
-      enabled: false
+      enabled: true
+      label_key: nodegroup_type
+      label_value: job

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -110,10 +110,10 @@ osm-seed:
     resources:
       enabled: true
       requests:
-        memory: "8Gi"
-        cpu: "2"
+        memory: "2Gi"
+        cpu: "1"
       limits:
-        memory: "8Gi"
+        memory: "2Gi"
         cpu: "2"
     autoscaling:
       enabled: true

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -121,10 +121,10 @@ osm-seed:
       resources:
         enabled: true
         requests:
-          memory: "8Gi"
-          cpu: "2"
+          memory: "2Gi"
+          cpu: "1"
         limits:
-          memory: "8Gi"
+          memory: "2Gi"
           cpu: "2"
       autoscaling:
         enabled: true

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -157,7 +157,7 @@ osm-seed:
         enabled: true
         label_key: nodegroup_type
         label_value: job
-      schedule: '0 */5 * * *'
+      schedule: '0 0 * * *'
       env:
         OVERWRITE_PLANET_FILE: true
       resources:
@@ -178,7 +178,7 @@ osm-seed:
         enabled: true
         label_key: nodegroup_type
         label_value: job
-      schedule: '0 */5 * * *'
+      schedule: '0 0 * * *'
       env:
         OVERWRITE_FHISTORY_FILE: false
       resources:
@@ -282,7 +282,7 @@ osm-seed:
   
     dbBackupRestore:
       enabled: true
-      schedule: '0 */5 * * *'
+      schedule: '0 0 * * *'
       nodeSelector:
         enabled: true
         label_key: nodegroup_type

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -121,15 +121,15 @@ osm-seed:
       resources:
         enabled: true
         requests:
-          memory: "500Mi"
-          cpu: "0.5"
+          memory: "8GB"
+          cpu: "2"
         limits:
-          memory: "1Gi"
-          cpu: "1"
+          memory: "8GB"
+          cpu: "2"
       autoscaling:
         enabled: true
         minReplicas: 2
-        maxReplicas: 15
+        maxReplicas: 10
         cpuUtilization: 80
     # ====================================================================================================
     # Variables for memcached. Memcached is used to store session cookies

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -310,7 +310,7 @@ osm-seed:
       nodeSelector:
         enabled: true
         label_key: nodegroup_type
-        label_value: tiler
+        label_value: db
       env:
         POSTGRES_HOST: {{STAGING_TILER_DB_HOST}}
         POSTGRES_DB: {{STAGING_TILER_DB}}
@@ -356,7 +356,7 @@ osm-seed:
       nodeSelector:
         enabled: true
         label_key: nodegroup_type
-        label_value: tiler
+        label_value: web
       env:
         TILER_IMPORT_FROM: osm
         TILER_IMPORT_PBF_URL: http://planet-staging.openhistoricalmap.org.s3.amazonaws.com/planet/planet-latest.osm.pbf
@@ -387,7 +387,7 @@ osm-seed:
       nodeSelector:
         enabled: true
         label_key: nodegroup_type
-        label_value: tiler
+        label_value: web
       replicaCount: 1
       commad: './start.sh'
       serviceAnnotations:
@@ -427,7 +427,7 @@ osm-seed:
       nodeSelector:
         enabled: true
         label_key: nodegroup_type
-        label_value: tiler
+        label_value: web
       replicaCount: 1
       command: './cache_cleaner.sh'
       resources:

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -119,19 +119,18 @@ osm-seed:
         NEW_RELIC_LICENSE_KEY: {{STAGING_NEW_RELIC_LICENSE_KEY}}
         NEW_RELIC_APP_NAME: {{STAGING_NEW_RELIC_APP_NAME}}
       resources:
-        enabled: false
+        enabled: true
         requests:
-          memory: "1Gi"
-          cpu: "2"
+          memory: "500Mi"
+          cpu: "0.5"
         limits:
-          memory: "2Gi"
-          cpu: "2"
+          memory: "1Gi"
+          cpu: "1"
       autoscaling:
         enabled: true
         minReplicas: 2
-        maxReplicas: 10
+        maxReplicas: 15
         cpuUtilization: 80
-        memoryUtilization: 1000Mi
     # ====================================================================================================
     # Variables for memcached. Memcached is used to store session cookies
     # ====================================================================================================
@@ -412,19 +411,18 @@ osm-seed:
         AWS_ElasticBlockStore_volumeID: {{STAGING_TILER_SERVER_EBS}}
         AWS_ElasticBlockStore_size: 100Gi
       resources:
-        enabled: false
+        enabled: true
         requests:
-          memory: "16Gi"
-          cpu: "8"
+          memory: "2Gi"
+          cpu: "1"
         limits:
-          memory: "16Gi"
-          cpu: "8"
+          memory: "10Gi"
+          cpu: "2"
       autoscaling:
         enabled: true
         minReplicas: 1
         maxReplicas: 2
-        cpuUtilization: 500
-        memoryUtilization: 500Mi
+        cpuUtilization: 60
     # ====================================================================================================
     # Variables for tiler-server cache cleaner, only avaliable in case the TILER_CACHE_TYPE = s3  
     # ====================================================================================================
@@ -437,19 +435,18 @@ osm-seed:
       replicaCount: 1
       command: './cache_cleaner.sh'
       resources:
-        enabled: false
-        requests:
-          memory: '1Gi'
-          cpu: '2'
-        limits:
-          memory: '2Gi'
-          cpu: '2'
-      autoscaling:
         enabled: true
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+        limits:
+          memory: "10Gi"
+          cpu: "2"
+      autoscaling:
+        enabled: false
         minReplicas: 1
         maxReplicas: 2
-        cpuUtilization: 500
-        memoryUtilization: 500Mi
+        cpuUtilization: 60
     # ====================================================================================================
     # Variables for tiler-visor
     # ====================================================================================================

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -127,10 +127,11 @@ osm-seed:
           memory: "2Gi"
           cpu: "2"
       autoscaling:
-        enabled: false
-        minReplicas: 1
-        maxReplicas: 3
+        enabled: true
+        minReplicas: 2
+        maxReplicas: 10
         cpuUtilization: 80
+        memoryUtilization: 1000Mi
     # ====================================================================================================
     # Variables for memcached. Memcached is used to store session cookies
     # ====================================================================================================
@@ -156,8 +157,8 @@ osm-seed:
       nodeSelector:
         enabled: true
         label_key: nodegroup_type
-        label_value: web
-      schedule: '0 0 * * *'
+        label_value: job
+      schedule: '0 */5 * * *'
       env:
         OVERWRITE_PLANET_FILE: true
       resources:
@@ -177,8 +178,8 @@ osm-seed:
       nodeSelector:
         enabled: true
         label_key: nodegroup_type
-        label_value: web
-      schedule: '0 0 * * *'
+        label_value: job
+      schedule: '0 */5 * * *'
       env:
         OVERWRITE_FHISTORY_FILE: false
       resources:
@@ -282,11 +283,11 @@ osm-seed:
   
     dbBackupRestore:
       enabled: true
-      schedule: '0 0 * * *'
+      schedule: '0 */5 * * *'
       nodeSelector:
         enabled: true
         label_key: nodegroup_type
-        label_value: db
+        label_value: job
       env:
         RESTORE_URL_FILE: https://osmseed-production-db.s3.us-east-1.amazonaws.com/database/osmseed-db-220802_0000.sql.gz?response-content-disposition=inline&X-Amz-Security-Token=IQoJb3JpZ2luX2VjECUaCXNhLWVhc3QtMSJIMEYCIQDaL%2BYJE0LIZ8dHisSghlpKYtIbqPM3r7OnlXYySl34FAIhAOYcyVdY7WxoWN9n3z%2Fkh6JkJkkHFV91PJ6qS4ZEloizKvsCCH4QAhoMNjE4MzgwMjQyMjQ3Igy6Fd%2BxFomzH%2F38Evwq2ALJG0LvPhoMjgxOeGv0uZQPjzMewvy0IzjExaMcMruXQkSxgCjLZzb2xJTmfPHqcT1iAN%2FYPcm87CuLMU6TZ7QdKQTbhPUIgIXsdQ1oscp8095EgaQr0pY%2F7gDfDlxrUjGnEN3FOUCYucFNn9ORlL%2BlNXCkOsaIIg0ByUyLHFfus7%2B8plA0GfAHwkXdJRyx4hmSXFzAhnDT0mqH0YjuiS5DevP0ykCLmF3hT3Xbwd81t%2FZ07mm8hwzAxLibIc5YqjrxxnLAuZR9AXHCH%2F4Q0HosKMVWpry%2BsjRuebUbNgKsb8M4e73xjN18b40feIFazI6Ypo2yTfsMhNM2t1swa%2FpMq%2B2qg5NlDM%2FP1KzwT2yvZ3cZnZ2o3wFTxCYRcVG0nz%2FYA6iirYwezO2JK37aaeqUaMzTSAwM46S9S2qtcyuz5qrP2%2FULcrILtxw8FHVk5uMbqcXpBOQxMDCkpKaXBjqyAsdeRIzom8r6pAwrr7yzldM3bEpDdpfah38i%2BVGoq4Vg1EfrTTrRJ1zM481yAK9VZ%2Bm8pH52NRXsf3KBvawHxfKWRS5RiY4lhU%2BcX0WxtgCicxSILzoD9xmU6PoiuCy4DUojES6CznkY1LXe10ccQn4URFYgSpx04JSvO6RW82BWXardXPtZXuaxw4bPD%2FNnp3UxXMpv8fTS9shlA98xaS4m7XYTbpNl5uere0HkGy4vi5IZYRY%2B%2B909WU9ALsvSHBE%2BZLiIND8r0V1y9zBL8jD9pgtZghVpc%2FyeQ4XPxxtxEDSvJi0m3Vr7IQC7kOxB%2BuHSafbTKH4oGCDD5con4b7GCImy7N0T5EbVEAkmmKvW9hAMDYhF0A3NOR8fEvNtPKZve0bEl0gmMJ07quqmOsd56A%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220802T223259Z&X-Amz-SignedHeaders=host&X-Amz-Expires=1200&X-Amz-Credential=ASIAY76SVVVDZNYKO7KN%2F20220802%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=2a60ec3375c1abffc83a9067732a76ee02be3611bbe0e3e297987dd37fc58365
         DB_ACTION: backup
@@ -418,7 +419,12 @@ osm-seed:
         limits:
           memory: "16Gi"
           cpu: "8"
-  
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 2
+        cpuUtilization: 500
+        memoryUtilization: 500Mi
     # ====================================================================================================
     # Variables for tiler-server cache cleaner, only avaliable in case the TILER_CACHE_TYPE = s3  
     # ====================================================================================================
@@ -438,7 +444,12 @@ osm-seed:
         limits:
           memory: '2Gi'
           cpu: '2'
-  
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 2
+        cpuUtilization: 500
+        memoryUtilization: 500Mi
     # ====================================================================================================
     # Variables for tiler-visor
     # ====================================================================================================
@@ -648,6 +659,6 @@ osm-seed:
           memory: '2Gi'
           cpu: '2'
       nodeSelector:
-        enabled: false
+        enabled: true
         label_key: nodegroup_type
-        label_value: web
+        label_value: job

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -121,10 +121,10 @@ osm-seed:
       resources:
         enabled: true
         requests:
-          memory: "8GB"
+          memory: "8Gi"
           cpu: "2"
         limits:
-          memory: "8GB"
+          memory: "8Gi"
           cpu: "2"
       autoscaling:
         enabled: true


### PR DESCRIPTION
Here are the necessary changes for the production installation, this new version includes:

Update to Kubernetes 1.27
Autoscaling for both the web and tiler servers.
Autoscaling for cron job pods.

cc. @batpad @geohacker @danrademacher 