### PR TITLE
Pass sequence number as string for imposm

### DIFF
--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -335,7 +335,7 @@ osm-seed:
       TILER_IMPORT_PBF_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-230727_1030.osm.pbf
       REPLICATION_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/replication/minute/
       OVERWRITE_STATE: true
-      SEQUENCE_NUMBER: 1064000
+      SEQUENCE_NUMBER: "1064000"
     persistenceDisk:
       enabled: true
       accessMode: ReadWriteOnce

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -361,7 +361,7 @@ osm-seed:
         TILER_IMPORT_FROM: osm
         TILER_IMPORT_PBF_URL: http://planet-staging.openhistoricalmap.org.s3.amazonaws.com/planet/planet-latest.osm.pbf
         REPLICATION_URL: http://planet-staging.openhistoricalmap.org.s3.amazonaws.com/replication/minute/
-        SEQUENCE_NUMBER: 485000
+        SEQUENCE_NUMBER: "485000"
         OVERWRITE_STATE: true
       persistenceDisk:
         enabled: true


### PR DESCRIPTION
In the current situation, when we pass large numbers in Kubernetes templates (more that 6 digits), they are converted to scientific notation, which leads to issues with recognition, particularly for imposm. Therefore, it is better to pass such numbers as strings.

cc. @batpad 