### PR TITLE
Remove tiler cache manually when container gets too busy.

### DIFF
--- a/images/tiler-server/Dockerfile
+++ b/images/tiler-server/Dockerfile
@@ -51,4 +51,5 @@ COPY ./expire-watcher.sh .
 COPY ./seed-by-diffs.sh .
 COPY ./tile_cache_downloader.sh .
 COPY ./cache_cleaner.sh .
+COPY ./rm_tegola_ps.sh .
 # CMD ./start.sh & ./tile_cache_downloader.sh & ./expire-watcher.sh

--- a/images/tiler-server/cache_cleaner.sh
+++ b/images/tiler-server/cache_cleaner.sh
@@ -3,5 +3,5 @@ flag=true
 while "$flag" = true; do
   pg_isready -h $POSTGRES_HOST -p 5432 >/dev/null 2>&2 || continue
   flag=false
-  ./tile_cache_downloader.sh & ./expire-watcher.sh
+  ./tile_cache_downloader.sh & ./expire-watcher.sh & ./rm_tegola_ps.sh
 done

--- a/images/tiler-server/rm_tegola_ps.sh
+++ b/images/tiler-server/rm_tegola_ps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+if [[ -n "${KILL_PROCESS}" && "${KILL_PROCESS}" == "manually" ]]; then
+    while true; do
+        NUM_PS=$(ps | grep ${PROCESS_NAME} | grep -v grep | wc -l)
+        if [[ $NUM_PS -gt $MAX_NUM_PS ]]; then
+            echo "${PROCESS_NAME} processes"
+            ps aux | grep ${PROCESS_NAME} | grep -v grep
+            # After clearing the S3 cache, terminate all 'tegola' processes.
+            killall ${PROCESS_NAME}
+            # Clean cache manually from s3
+            aws s3 rm s3://${TILER_CACHE_BUCKET}/mnt/data/osm/ --recursive
+        fi
+        sleep 600
+    done
+fi

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: osm-seed
-  version: '0.1.0-n771.h5ab71b9'
+  version: '0.1.0-n768.h455eb76'
   repository: https://devseed.com/osm-seed-chart/

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -415,11 +415,15 @@ osm-seed:
       limits:
         memory: "10Gi"
         cpu: "2"
+    env:
+      KILL_PROCESS: manually
+      MAX_NUM_PS: 5
+      PROCESS_NAME: tegola
     autoscaling:
-      enabled: false
+      enabled: true
       minReplicas: 1
-      maxReplicas: 2
-      cpuUtilization: 60
+      maxReplicas: 1
+      cpuUtilization: 90
   # ====================================================================================================
   # Variables for tiler-visor
   # ====================================================================================================

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -444,8 +444,8 @@ osm-seed:
           cpu: "2"
       env:
         KILL_PROCESS: manually
-        MAX_NUM_PS: 3
-        PROCESS_NAME: bash
+        MAX_NUM_PS: 4
+        PROCESS_NAME: tegola
       autoscaling:
         enabled: true
         minReplicas: 1

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -394,7 +394,7 @@ osm-seed:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
       env:
         TILER_SERVER_PORT: 9090
-        TILER_CACHE_TYPE: file
+        TILER_CACHE_TYPE: s3
         TILER_CACHE_BASEPATH: /mnt/data
         TILER_CACHE_MAX_ZOOM: 22
         # in case s3
@@ -442,11 +442,15 @@ osm-seed:
         limits:
           memory: "10Gi"
           cpu: "2"
+      env:
+        KILL_PROCESS: manually
+        MAX_NUM_PS: 3
+        PROCESS_NAME: bash
       autoscaling:
-        enabled: false
+        enabled: true
         minReplicas: 1
-        maxReplicas: 2
-        cpuUtilization: 60
+        maxReplicas: 1
+        cpuUtilization: 90
     # ====================================================================================================
     # Variables for tiler-visor
     # ====================================================================================================

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -394,7 +394,7 @@ osm-seed:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
       env:
         TILER_SERVER_PORT: 9090
-        TILER_CACHE_TYPE: s3
+        TILER_CACHE_TYPE: file
         TILER_CACHE_BASEPATH: /mnt/data
         TILER_CACHE_MAX_ZOOM: 22
         # in case s3


### PR DESCRIPTION
The following script is designed to remove processes that overload the `tiler-server-cache-cleaner`  container. This is especially relevant when the tegola process doesn't finish and spawns numerous processes due to extensive editing on the api-server. We manually eliminate the tegola processes and also clear the S3 cache by hand,  removing the exiting tiles in s3 in case all cache in tiler server. 

cc. @batpad @danrademacher 