### PR TITLE
Adding Shared memory for web container

### DIFF
--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: osm-seed
-  version: '0.1.0-n807.h2a372ea'
+  version: '0.1.0-n808.hbf9aacf'
   repository: https://devseed.com/osm-seed-chart/

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -120,6 +120,8 @@ osm-seed:
       minReplicas: 2
       maxReplicas: 10
       cpuUtilization: 80
+    sharedMemorySize: 512Mi
+
   # ====================================================================================================
   # Variables for memcached. Memcached is used to store session cookies
   # ====================================================================================================

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -130,7 +130,7 @@ osm-seed:
         minReplicas: 2
         maxReplicas: 10
         cpuUtilization: 80
-      sharedMemorySize: 1Mi
+      sharedMemorySize: 128Mi
     # ====================================================================================================
     # Variables for memcached. Memcached is used to store session cookies
     # ====================================================================================================

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -130,7 +130,7 @@ osm-seed:
         minReplicas: 2
         maxReplicas: 10
         cpuUtilization: 80
-      sharedMemorySize: 512Mi
+      sharedMemorySize: 1Mi
     # ====================================================================================================
     # Variables for memcached. Memcached is used to store session cookies
     # ====================================================================================================

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -130,6 +130,7 @@ osm-seed:
         minReplicas: 2
         maxReplicas: 10
         cpuUtilization: 80
+      sharedMemorySize: 512Mi
     # ====================================================================================================
     # Variables for memcached. Memcached is used to store session cookies
     # ====================================================================================================


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/633

 By default,  the shared memory size is 64 MB, pointing  to `/dev/shm`, I am adding 512 MB as shared memory size for production container ; let's see how that works. that should be enough to avoid the issue.

cc. @batpad @1ec5 