### PR TITLE
Disable uploads action for CGIMAP

### DIFF
--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -36,10 +36,10 @@
     RewriteRule ^/api/0\.6/(way|relation)/[0-9]+/full(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
     RewriteRule ^/api/0\.6/(nodes|ways|relations)(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
 
-    # For changeset requests originating from TM, do not use cgimap.
-    RewriteCond %{REQUEST_METHOD} ^POST$
-    RewriteCond %{HTTP_REFERER} !^https://tasks(-\w+)?\.openhistoricalmap\.org/ [NC]
-    RewriteRule ^/api/0\.6/changeset/[0-9]+/(upload|download)(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
+    # # For changeset requests originating from TM, do not use cgimap.
+    # RewriteCond %{REQUEST_METHOD} ^POST$
+    # RewriteCond %{HTTP_REFERER} !^https://tasks(-\w+)?\.openhistoricalmap\.org/ [NC]
+    # RewriteRule ^/api/0\.6/changeset/[0-9]+/(upload|download)(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
 
     # Relax Apache security settings
     <Directory /var/www/public>


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/633
Per voice with Sanjay, we decided to disable the upload option using cgimap in order to avoid failing any changes and have time to recreate the issue  about shared memory in staging.

cc. @batpad @danrademacher 