### PR TITLE
Reduce the number of connections to the database from CGImap

### DIFF
--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -65,7 +65,7 @@ while "$flag" = true; do
   /usr/local/bin/openstreetmap-cgimap \
     --port=8000 \
     --daemon \
-    --instances=30 \
+    --instances=10 \
     --dbname=$POSTGRES_DB \
     --host=$POSTGRES_HOST \
     --username=$POSTGRES_USER \


### PR DESCRIPTION
Having 30 instances connected to the DB  for cgimap is generating issues 

```
[Worker(host:production-osm-seed-web-5c9c5db786-zbw9g pid:275)] Starting job worker
[Worker(host:production-osm-seed-web-5c9c5db786-zbw9g pid:275)] Error while reserving job: connection to server at "172.20.67.93", port 5432 failed: FATAL:  sorry, too many clients already
[Worker(host:production-osm-seed-web-5c9c5db786-zbw9g pid:275)] Error while reserving job: connection to server at "172.20.67.93", port 5432 failed: FATAL:  sorry, too many clients already
[Worker(host:production-osm-seed-web-5c9c5db786-zbw9g pid:275)] Error while reserving job: connection to server at "172.20.67.93", port 5432 failed: FATAL:  sorry, too many clients already
[Worker(host:production-osm-seed-web-5c9c5db786-zbw9g pid:275)] Error while reserving job: connection to server at "172.20.67.93", port 5432 failed: FATAL:  sorry, too many clients already
[Worker(host:production-osm-seed-web-5c9c5db786-zbw9g pid:275)] Error while reserving job: connection to server at "172.20.67.93", port 5432 failed: FATAL:  sorry, too many clients already
[Worker(host:production-osm-seed-web-5c9c5db786-zbw9g pid:2
```
I am reducing the number of connection to   DB to 10 . 

cc. @batpad @1ec5 @danrademacher @mmd-osm