### PR TITLE
update mapstyle, move to MapLibre, update iD

### DIFF
--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -48,13 +48,13 @@ RUN npm install -g svgo
 
 # Install openstreetmap-website
 RUN rm -rf $workdir/html
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=ed33dfeebb7460031d7339e3fe29e7f8fb2b3a18
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=70c167d9ed7ac24b26c575c0ca023e6349ed7303
 RUN git clone -b staging https://github.com/OpenHistoricalMap/ohm-website.git $workdir
 WORKDIR $workdir
 RUN git checkout $OPENHISTORICALMAP_WEBSITE_GITSHA
 
 # change the echo here with a reason for changing the commithash
-RUN echo 'update mapstyle and translate wiki'
+RUN echo 'update mapstyle, move to MapLibre, update iD'
 RUN git fetch
 
 # Install Ruby packages

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -48,13 +48,13 @@ RUN npm install -g svgo
 
 # Install openstreetmap-website
 RUN rm -rf $workdir/html
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=70c167d9ed7ac24b26c575c0ca023e6349ed7303
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=00bd7fddee2bd214d0ad3cda81e8c294b0d4c48d
 RUN git clone -b staging https://github.com/OpenHistoricalMap/ohm-website.git $workdir
 WORKDIR $workdir
 RUN git checkout $OPENHISTORICALMAP_WEBSITE_GITSHA
 
 # change the echo here with a reason for changing the commithash
-RUN echo 'update mapstyle, move to MapLibre, update iD'
+RUN echo 'update gems, mapstyle, move to MapLibre, update iD'
 RUN git fetch
 
 # Install Ruby packages


### PR DESCRIPTION
This pulls in latest changes on ohm-website, which are tested locally, but the Chartpress Build and Deploy action is failing.

When I look here it seems like we've not had a successful Chartpress completion since about 3 weeks ago:
https://github.com/OpenHistoricalMap/ohm-deploy/actions/workflows/chartpress.yaml

Not sure yet what is causing this issue. The errors in my first attempt show up here:
https://github.com/OpenHistoricalMap/ohm-deploy/actions/runs/7333787524/job/19969695540#step:7:5013

Something about `rake assets precompile`, though Rails is building fine locally.

I tried just rerunning it, in case it was a transient glitch, same outcome.