### PR TITLE
Update osm-seed version - osmcha

### DIFF
--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: osm-seed
-  version: '0.1.0-n775.h6785acb'
+  version: '0.1.0-n777.he5c57fc'
   repository: https://devseed.com/osm-seed-chart/


### PR DESCRIPTION
Add a CLI `python manage.py backfill_changesets $(date -d "yesterday" +%Y-%m-%d) $(date +%Y-%m-%d)` in the cronjob to run updates in case of missing changeset from the day before.

From: https://github.com/OpenHistoricalMap/issues/issues/712