### PR TITLE
Config for ingress-nginx  

### DIFF
--- a/.github/workflows/frontend-nominatim.yaml
+++ b/.github/workflows/frontend-nominatim.yaml
@@ -17,7 +17,7 @@ jobs:
         if: github.ref == 'refs/heads/staging'
         uses: allenevans/set-env@v2.0.0
         with:
-          NOMINATIM_API: 'https://nominatim-api-staging.openhistoricalmap.org/'
+          NOMINATIM_API: 'https://nominatim-api.staging.openhistoricalmap.org/'
           NOMINATIM_BUCKET: 'nominatim-staging.openhistoricalmap.org'
           CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.STAGING_NOMINATIM_CLOUDFRONT_ID }}
 

--- a/.github/workflows/frontend-overpass.yaml
+++ b/.github/workflows/frontend-overpass.yaml
@@ -17,7 +17,7 @@ jobs:
         if: github.ref == 'refs/heads/staging'
         uses: allenevans/set-env@v2.0.0
         with:
-          OVERPASS_API: overpass-api-staging.openhistoricalmap.org
+          OVERPASS_API: overpass-api.staging.openhistoricalmap.org
           OVERPASS_BUCKET: overpass-turbo-staging.openhistoricalmap.org
           CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.STAGING_OVERPASS_CLOUDFRONT_ID }}
 

--- a/.github/workflows/frontend-tasking-manager.yaml
+++ b/.github/workflows/frontend-tasking-manager.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: allenevans/set-env@v2.0.0
         with:
           TM_APP_BASE_URL: https://tasks-staging.openhistoricalmap.org
-          TM_APP_API_URL: https://staging-tm-api.openhistoricalmap.org
+          TM_APP_API_URL: https://tm-api.staging.openhistoricalmap.org
           TM_APP_API_VERSION: v2
           TM_ORG_NAME: OpenHistoricalMap
           TM_ORG_CODE: OHM

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: osm-seed
-  version: '0.1.0-n777.he5c57fc'
+  version: '0.1.0-n785.h9c60673'
   repository: https://devseed.com/osm-seed-chart/

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -105,6 +105,7 @@ osm-seed:
       staticIp: c
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+      ingressDomain: osmcha.staging.openhistoricalmap.org
       env:
         MAILER_ADDRESS: {{MAILER_ADDRESS}}
         MAILER_DOMAIN: staging.openhistoricalmap.org
@@ -427,6 +428,7 @@ osm-seed:
       commad: './start.sh'
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+      ingressDomain: vtiles.staging.openhistoricalmap.org
       env:
         TILER_SERVER_PORT: 9090
         TILER_CACHE_TYPE: s3
@@ -527,6 +529,7 @@ osm-seed:
       staticIp: c
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+      ingressDomain: tm-api.staging.openhistoricalmap.org
       env:
         POSTGRES_HOST: {{STAGING_TM_API_DB_HOST}}
         POSTGRES_DB: {{STAGING_TM_API_DB}}
@@ -572,6 +575,7 @@ osm-seed:
       enabled: false
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+      ingressDomain: nominatim-api.staging.openhistoricalmap.org
       replicaCount: 1
       env:
         PBF_URL: https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-240108_0000.osm.pbf
@@ -622,6 +626,7 @@ osm-seed:
       enabled: true
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+        ingressDomain: overpass-api.staging.openhistoricalmap.org
       env:
         OVERPASS_META: 'attic'
         OVERPASS_MODE: 'init'
@@ -658,6 +663,7 @@ osm-seed:
         label_value: web
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+      ingressDomain: taginfo.staging.openhistoricalmap.org
       env:
         URL_PLANET_FILE_STATE: https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/state.txt
         URL_HISTORY_PLANET_FILE_STATE: https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/full-history/state.txt
@@ -746,6 +752,7 @@ osm-seed:
       image:
         name: "ghcr.io/openhistoricalmap/osmcha-django"
         tag: "a1bcea85dc1f7c27566c20bafe7fff7aaa1e38a4"
+      ingressDomain: osmcha.staging.openhistoricalmap.org
       env:
         DJANGO_SETTINGS_MODULE: "config.settings.production"
         OSMCHA_FRONTEND_VERSION: "v0.86.0-production"

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -105,7 +105,7 @@ osm-seed:
       staticIp: c
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
-      ingressDomain: osmcha.staging.openhistoricalmap.org
+      ingressDomain: www.staging.openhistoricalmap.org
       env:
         MAILER_ADDRESS: {{MAILER_ADDRESS}}
         MAILER_DOMAIN: staging.openhistoricalmap.org
@@ -115,8 +115,8 @@ osm-seed:
         OAUTH_CLIENT_ID: {{STAGING_OAUTH_CLIENT_ID}}
         OAUTH_KEY: {{STAGING_OAUTH_KEY}}
         MAILER_FROM: no-reply@staging.openhistoricalmap.org
-        NOMINATIM_URL: nominatim-api-staging.openhistoricalmap.org
-        OVERPASS_URL: overpass-api-staging.openhistoricalmap.org	
+        NOMINATIM_URL: nominatim-api.staging.openhistoricalmap.org
+        OVERPASS_URL: overpass-api.staging.openhistoricalmap.org	
         NEW_RELIC_LICENSE_KEY: {{STAGING_NEW_RELIC_LICENSE_KEY}}
         NEW_RELIC_APP_NAME: {{STAGING_NEW_RELIC_APP_NAME}}
         ORGANIZATION_NAME: OpenHistoricalMap


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/725
Her is the configuration  for removing classic ELB and start using ingress-nginx  which  will reduce the cost from ELB in AWS. 

cc. @batpad @danrademacher @jeffreyameyer 