### PR TITLE
Disable Transport lines from relations - vtiles

### DIFF
--- a/images/tiler-server/config/config.template.toml
+++ b/images/tiler-server/config/config.template.toml
@@ -71,9 +71,6 @@ max_connections = 50
 	###### transport_associated_streets
 	[['providers/transport_associated_streets.toml']]
 
-	###### Transport lines from relations
-	[['providers/transport_lines_relation.toml']]
-	
 [[maps]]
 name = "osm"
 attribution = "OpenHistoricalMap"


### PR DESCRIPTION
It seems the transport lines from relations are causing some issues https://github.com/OpenHistoricalMap/issues/issues/761#issuecomment-2073900273. I am going to disable them for now, since there are no official styles for it. https://github.com/OpenHistoricalMap/issues/issues/761#issuecomment-2063964407

cc. @1ec5 @vknoppkewetzel