### PR TITLE
Update Map-Styles using python script 

### DIFF
--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -116,8 +116,9 @@ RUN chown -R www-data: $workdir
 
 # Clone Map-styles
 ENV OPENHISTORICALMAP_MAP_STYLES_GITSHA=88831a32995cd5f59bd6a7dea36feaa1dbfe4ef6
-RUN git clone https://github.com/OpenHistoricalMap/map-styles.git $workdir/map-styles
-RUN cd $workdir/map-styles && git checkout $OPENHISTORICALMAP_MAP_STYLES_GITSHA
+RUN git clone --branch staging --depth 1 https://github.com/OpenHistoricalMap/map-styles.git $workdir/public/map-styles
+RUN cd $workdir/public/map-styles && git fetch --depth 1 origin $OPENHISTORICALMAP_MAP_STYLES_GITSHA && git checkout $OPENHISTORICALMAP_MAP_STYLES_GITSHA
+RUN rm -rf $workdir/public/map-styles/.git
 COPY update_map_styles.py $workdir/
 
 # Add settings

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -115,7 +115,7 @@ RUN apache2ctl configtest
 RUN chown -R www-data: $workdir
 
 # Clone Map-styles
-ENV OPENHISTORICALMAP_MAP_STYLES_GITSHA=ccb32341985a3c318d8476b112579231c4cfccf2
+ENV OPENHISTORICALMAP_MAP_STYLES_GITSHA=88831a32995cd5f59bd6a7dea36feaa1dbfe4ef6
 RUN git clone https://github.com/OpenHistoricalMap/map-styles.git $workdir/map-styles
 RUN cd $workdir/map-styles && git checkout $OPENHISTORICALMAP_MAP_STYLES_GITSHA
 COPY update_map_styles.py $workdir/

--- a/images/web/update_map_styles.py
+++ b/images/web/update_map_styles.py
@@ -6,27 +6,22 @@ SERVER_URL = os.getenv("SERVER_URL", "www.openhistoricalmap.org")
 environment = "staging" if "staging" in SERVER_URL else "production"
 files = {
     "ohmVectorStyles.Original = ": {
-        "map-styles": "map-styles/main/main.json",
-        "ohm-website": "app/assets/javascripts/ohm.style.original.js",
-        "spritesheet_dir": "map-styles/main",
+        "map-styles": "/var/www/public/map-styles/main/main.json",
+        "ohm-website": "/var/www/app/assets/javascripts/ohm.style.original.js",
     },
     "ohmVectorStyles.Railway = ": {
-        "map-styles": "map-styles/rail/rail.json",
-        "ohm-website": "app/assets/javascripts/ohm.style.railway.js",
-        "spritesheet_dir": "map-styles/rail",
+        "map-styles": "/var/www/public/map-styles/rail/rail.json",
+        "ohm-website": "/var/www/app/assets/javascripts/ohm.style.railway.js",
     },
     "ohmVectorStyles.Woodblock = ": {
-        "map-styles": "map-styles/woodblock/woodblock.json",
-        "ohm-website": "app/assets/javascripts/ohm.style.woodblock.js",
-        "spritesheet_dir": "map-styles/woodblock",
+        "map-styles": "/var/www/public/map-styles/woodblock/woodblock.json",
+        "ohm-website": "/var/www/app/assets/javascripts/ohm.style.woodblock.js",
     },
     "ohmVectorStyles.JapaneseScroll = ": {
-        "map-styles": "map-styles/japanese_scroll/ohm-japanese-scroll-map.json",
-        "ohm-website": "app/assets/javascripts/ohm.style.japanese.js",
-        "spritesheet_dir": "map-styles/japanese_scroll",
+        "map-styles": "/var/www/public/map-styles/japanese_scroll/ohm-japanese-scroll-map.json",
+        "ohm-website": "/var/www/app/assets/javascripts/ohm.style.japanese.js",
     },
 }
-
 
 # Read json data from map-styles
 def read_json_file(file_path):
@@ -47,16 +42,6 @@ def write_json_file(js_file_path, key, json_data):
         print(f"Error updating {js_file_path}: {e}")
 
 
-# Copy directory to public/styles/
-def copy_directory(src_dir, dest_dir):
-    try:
-        if os.path.exists(dest_dir):
-            shutil.rmtree(dest_dir)
-        shutil.copytree(src_dir, dest_dir)
-    except Exception as e:
-        print(f"Error copying directory {src_dir} to {dest_dir}: {e}")
-
-
 # Loop through files
 for key, value in files.items():
     if "map-styles" in value:
@@ -73,18 +58,14 @@ for key, value in files.items():
                         "vtiles.openhistoricalmap.org",
                     )
                     .replace(
-                        "openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet",
-                        "openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet-production",
-                    )
-                    .replace(
-                        "openhistoricalmap.github.io/map-styles",
-                        "www.openhistoricalmap.org/styles",
+                        "openhistoricalmap.github.io",
+                        "www.openhistoricalmap.org",
                     )
                 )
             else:
                 json_str = json_str.replace(
-                    "openhistoricalmap.github.io/map-styles",
-                    "staging.openhistoricalmap.org/styles",
+                    "openhistoricalmap.github.io",
+                    "staging.openhistoricalmap.org",
                 )
 
             json_data = json.loads(json_str)
@@ -92,11 +73,4 @@ for key, value in files.items():
             ohm_website_path = value["ohm-website"]
             # Overwrite style file
             write_json_file(ohm_website_path, key, json_data)
-            
-            # Copy spritesheet to public dir
-            spritesheet_src_dir = value["spritesheet_dir"]
-            spritesheet_dest_dir = os.path.join(
-                "public", "styles", os.path.basename(spritesheet_src_dir)
-            )
-            copy_directory(spritesheet_src_dir, spritesheet_dest_dir)
             print(f"Updated map-style: {ohm_website_path}")

--- a/images/web/update_map_styles.py
+++ b/images/web/update_map_styles.py
@@ -6,9 +6,9 @@ SERVER_URL = os.getenv("SERVER_URL", "www.openhistoricalmap.org")
 environment = "staging" if "staging" in SERVER_URL else "production"
 files = {
     "ohmVectorStyles.Original = ": {
-        "map-styles": "map-styles/ohm_timeslider_tegola/tegola-ohm-production.json",
+        "map-styles": "map-styles/main/main.json",
         "ohm-website": "app/assets/javascripts/ohm.style.original.js",
-        "spritesheet_dir": "map-styles/ohm_timeslider_tegola",
+        "spritesheet_dir": "map-styles/main",
     },
     "ohmVectorStyles.Railway = ": {
         "map-styles": "map-styles/rail/rail.json",

--- a/images/web/update_map_styles.py
+++ b/images/web/update_map_styles.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 
 SERVER_URL = os.getenv("SERVER_URL", "www.openhistoricalmap.org")
 environment = "staging" if "staging" in SERVER_URL else "production"
@@ -7,20 +8,25 @@ files = {
     "ohmVectorStyles.Original = ": {
         "map-styles": "map-styles/ohm_timeslider_tegola/tegola-ohm-production.json",
         "ohm-website": "app/assets/javascripts/ohm.style.original.js",
+        "spritesheet_dir": "map-styles/ohm_timeslider_tegola",
     },
     "ohmVectorStyles.Railway = ": {
         "map-styles": "map-styles/rail/rail.json",
         "ohm-website": "app/assets/javascripts/ohm.style.railway.js",
+        "spritesheet_dir": "map-styles/rail",
     },
     "ohmVectorStyles.Woodblock = ": {
         "map-styles": "map-styles/woodblock/woodblock.json",
         "ohm-website": "app/assets/javascripts/ohm.style.woodblock.js",
+        "spritesheet_dir": "map-styles/woodblock",
     },
     "ohmVectorStyles.JapaneseScroll = ": {
         "map-styles": "map-styles/japanese_scroll/ohm-japanese-scroll-map.json",
         "ohm-website": "app/assets/javascripts/ohm.style.japanese.js",
+        "spritesheet_dir": "map-styles/japanese_scroll",
     },
 }
+
 
 # Read json data from map-styles
 def read_json_file(file_path):
@@ -31,7 +37,8 @@ def read_json_file(file_path):
         print(f"Error reading {file_path}: {e}")
         return None
 
-# Read json data in ohm-website
+
+# Write json data to ohm-website
 def write_json_file(js_file_path, key, json_data):
     try:
         with open(js_file_path, "w") as file:
@@ -39,23 +46,57 @@ def write_json_file(js_file_path, key, json_data):
     except Exception as e:
         print(f"Error updating {js_file_path}: {e}")
 
-# Loop files
+
+# Copy directory to public/styles/
+def copy_directory(src_dir, dest_dir):
+    try:
+        if os.path.exists(dest_dir):
+            shutil.rmtree(dest_dir)
+        shutil.copytree(src_dir, dest_dir)
+    except Exception as e:
+        print(f"Error copying directory {src_dir} to {dest_dir}: {e}")
+
+
+# Loop through files
 for key, value in files.items():
     if "map-styles" in value:
         file_path = value["map-styles"]
         json_data = read_json_file(file_path)
+
         if json_data:
-            # Replace in case production
+            json_str = json.dumps(json_data, indent=4)
+            # Replace in case of production
             if environment == "production":
-                json_str = json.dumps(json_data, indent=4)
-                json_str = json_str.replace(
-                    "vtiles.staging.openhistoricalmap.org",
-                    "vtiles.openhistoricalmap.org",
-                ).replace(
-                    "openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet",
-                    "openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet-production",
+                json_str = (
+                    json_str.replace(
+                        "vtiles.staging.openhistoricalmap.org",
+                        "vtiles.openhistoricalmap.org",
+                    )
+                    .replace(
+                        "openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet",
+                        "openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet-production",
+                    )
+                    .replace(
+                        "openhistoricalmap.github.io/map-styles",
+                        "www.openhistoricalmap.org/styles",
+                    )
                 )
-                json_data = json.loads(json_str)
+            else:
+                json_str = json_str.replace(
+                    "openhistoricalmap.github.io/map-styles",
+                    "staging.openhistoricalmap.org/styles",
+                )
+
+            json_data = json.loads(json_str)
+
             ohm_website_path = value["ohm-website"]
+            # Overwrite style file
             write_json_file(ohm_website_path, key, json_data)
+            
+            # Copy spritesheet to public dir
+            spritesheet_src_dir = value["spritesheet_dir"]
+            spritesheet_dest_dir = os.path.join(
+                "public", "styles", os.path.basename(spritesheet_src_dir)
+            )
+            copy_directory(spritesheet_src_dir, spritesheet_dest_dir)
             print(f"Updated map-style: {ohm_website_path}")


### PR DESCRIPTION
From : https://github.com/OpenHistoricalMap/issues/issues/792
@danrademacher I took the latest commit from https://github.com/OpenHistoricalMap/map-styles/tree/deploy-cleanup and cloned it into the public directory and all the files are available publicly now. Also I replaced the required files in the ohm-website using the Python script. 