### PR TITLE
Fix issues VACUUM and ANALYZE  in tiler server

### DIFF
--- a/images/tiler-server/start.sh
+++ b/images/tiler-server/start.sh
@@ -5,9 +5,25 @@ flag=true
 while "$flag" = true; do
   pg_isready -h $POSTGRES_HOST -U $POSTGRES_USER -p $POSTGRES_PORT >/dev/null 2>&1 || continue
   flag=false
-  echo "Running VACUUM and ANALYZE for tables"
+  echo "Running VACUUM and ANALYZE for tables to refresh the tables"
+  tables=$(psql -U "$POSTGRES_USER" -h "$POSTGRES_HOST" -d "$POSTGRES_DB" -Atc "SELECT tablename FROM pg_tables WHERE schemaname = 'public';")
+  for table in $tables; do
+      echo "---------------------------------------------"
+      echo "Processing table: $table"
+      # Run VACUUM
+      start_time=$(date +%s)
+      psql -U "$POSTGRES_USER" -h "$POSTGRES_HOST" -d "$POSTGRES_DB" -c "VACUUM $table;" > /dev/null 2>&1
+      end_time=$(date +%s)
+      elapsed_time=$((end_time - start_time))
+      echo "VACUUM completed for $table in $elapsed_time seconds."
 
-  # Set temporary statement_timeout
-  time psql -U $POSTGRES_USER -h $POSTGRES_HOST -d $POSTGRES_DB -c "SET statement_timeout = '300000'; DO \$\$ DECLARE r RECORD; BEGIN FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP EXECUTE 'VACUUM ' || r.tablename; EXECUTE 'ANALYZE ' || r.tablename; END LOOP; END \$\$;"
+      # Run ANALYZE
+      start_time=$(date +%s)
+      psql -U "$POSTGRES_USER" -h "$POSTGRES_HOST" -d "$POSTGRES_DB" -c "ANALYZE $table;" > /dev/null 2>&1
+      end_time=$(date +%s)
+      elapsed_time=$((end_time - start_time))
+      echo "ANALYZE completed for $table in $elapsed_time seconds."
+  done
+
   TEGOLA_SQL_DEBUG=LAYER_SQL:EXECUTE_SQL tegola serve --config=/opt/tegola_config/config.toml
 done

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: osm-seed
-    version: '0.1.0-n804.h07b1ec0'
+    version: '0.1.0-n802.h10eca67'
     repository: https://devseed.com/osm-seed-chart/

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -484,7 +484,7 @@ osm-seed:
       enabled: true
       label_key: nodegroup_type
       label_value: web
-    replicaCount: 3
+    replicaCount: 1
     commad: './start.sh'
     serviceAnnotations:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
@@ -517,8 +517,8 @@ osm-seed:
         cpu: "2"
     autoscaling:
       enabled: true
-      minReplicas: 3
-      maxReplicas: 5
+      minReplicas: 1
+      maxReplicas: 3
       cpuUtilization: 60  
   # ====================================================================================================
   # Variables for tiler-server cache cleaner, only avaliable in case the TILER_CACHE_TYPE = s3  

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -375,10 +375,10 @@ osm-seed:
     resources:
       enabled: true
       requests:
-        memory: "30Gi"
-        cpu: "7000m"
+        memory: "29Gi"
+        cpu: "7500m"
       limits:
-        memory: "31Gi"
+        memory: "29Gi"
         cpu: "7600m"
     postgresqlConfig:
       enabled: true


### PR DESCRIPTION
There is an issue when with the tiler server starting. 

```sh
SET
ERROR:  VACUUM cannot run inside a transaction block
CONTEXT:  SQL statement "VACUUM spatial_ref_sys"
PL/pgSQL function inline_code_block line 1 at EXECUTE
```

The VACUUM and ANALYZE process has not been running properly. for the tables because  of the above error Therefore, the rule is: every time a tiler server starts, we need to run VACUUM and ANALYZE to optimize the database tables. so i have updated the script .


cc. @1ec5 