### PR TITLE
Change db tiler host to AWS

### DIFF
--- a/images/tiler-imposm/start.sh
+++ b/images/tiler-imposm/start.sh
@@ -180,7 +180,7 @@ function importData() {
     # Update tables
     python update_tables.py
     
-    echo "Create Table/Tigger for osm_relation_menbers_routes_merged"
+    echo "Create Table/Tigger for admin_boundaries_centroids"
     # psql $PG_CONNECTION -f queries/osm_relation_menbers_routes_table.sql
     # psql $PG_CONNECTION -f queries/osm_relation_menbers_routes_trigger.sql
     psql $PG_CONNECTION -f queries/admin_boundaries_centroids.sql

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -355,7 +355,7 @@ osm-seed:
   tilerDb:
     enabled: true
     useExternalHost: # When we are using useExternalHost.enabled= true other variables are giong to be disable ans use the external host config
-      enabled: true
+      enabled: false
     nodeSelector:
       enabled: true
       label_key: nodegroup_type
@@ -373,7 +373,7 @@ osm-seed:
       mountPath: /var/lib/postgresql/data
       subPath: postgresql-d
       # In case cloudProvider: aws
-      AWS_ElasticBlockStore_volumeID: vol-0f115833b63d73efe
+      AWS_ElasticBlockStore_volumeID: vol-07b5a7a8e85a6caee
       AWS_ElasticBlockStore_size: 200Gi
     resources:
       enabled: true
@@ -467,7 +467,7 @@ osm-seed:
       accessMode: ReadWriteOnce
       mountPath: /mnt/data
       # In case cloudProvider: aws
-      AWS_ElasticBlockStore_volumeID: vol-0027ab7b9d50a5e90
+      AWS_ElasticBlockStore_volumeID: vol-05d06ac388569461f
       AWS_ElasticBlockStore_size: 50Gi
     resources:
       enabled: true

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -969,7 +969,7 @@ ohm:
     env:
       GEOJSON_URL: https://osmseed-dev.s3.us-east-1.amazonaws.com/tiler/usa-eu.geojson
       ZOOM_LEVELS: '8,9,10'
-      CONCURRENCY: 200
+      CONCURRENCY: 100
       S3_BUCKET: osmseed-dev
       OUTPUT_FILE: /logs/tiler_benchmark.log
     resources:


### PR DESCRIPTION
I am going to change the host for the Tiler database to AWS, since the issue ARM65 Hetzner still still affect the performance for imposm.

cc. @1ec5 @danrademacher @batpad @jeffreyameyer 