### PR TITLE
Release iD 2.29.3,  license update and map-styles redirects

### DIFF
--- a/images/cgimap/Dockerfile
+++ b/images/cgimap/Dockerfile
@@ -37,9 +37,9 @@ ENV CGIMAP_GITSHA=8ea707e10aeab5698e6859856111816d75354592
 RUN git clone -b master https://github.com/zerebubuth/openstreetmap-cgimap.git $cgimap \
     && cd $cgimap \
     && git checkout $CGIMAP_GITSHA \
-    && sed -i 's/OpenStreetMap/OpenHistoricalMap/g' include/cgimap/output_formatter.hpp \
-    && sed -i 's|http://www.openstreetmap.org/copyright|https://www.openhistoricalmap.org/copyright|g' include/cgimap/output_formatter.hpp \
-    && sed -i 's|http://opendatacommons.org/licenses/odbl/1-0/|https://creativecommons.org/public-domain/cc0/|g' include/cgimap/output_formatter.hpp \
+    && sed -i 's#OpenStreetMap and contributors#OpenHistoricalMap is dedicated to the public domain except where otherwise noted.#g' include/cgimap/output_formatter.hpp \
+    && sed -i 's#http://www.openstreetmap.org/copyright#https://www.openhistoricalmap.org/copyright#g' include/cgimap/output_formatter.hpp \
+    && sed -i 's#http://opendatacommons.org/licenses/odbl/1-0/#https://creativecommons.org/public-domain/cc0/#g' include/cgimap/output_formatter.hpp \
     && rm -rf .git \
     && mkdir build \
     && cd build \

--- a/images/cgimap/Dockerfile
+++ b/images/cgimap/Dockerfile
@@ -37,12 +37,15 @@ ENV CGIMAP_GITSHA=8ea707e10aeab5698e6859856111816d75354592
 RUN git clone -b master https://github.com/zerebubuth/openstreetmap-cgimap.git $cgimap \
     && cd $cgimap \
     && git checkout $CGIMAP_GITSHA \
+    && sed -i 's/OpenStreetMap/OpenHistoricalMap/g' include/cgimap/output_formatter.hpp \
+    && sed -i 's|http://www.openstreetmap.org/copyright|https://www.openhistoricalmap.org/copyright|g' include/cgimap/output_formatter.hpp \
+    && sed -i 's|http://opendatacommons.org/licenses/odbl/1-0/|https://creativecommons.org/public-domain/cc0/|g' include/cgimap/output_formatter.hpp \
     && rm -rf .git \
     && mkdir build \
     && cd build \
     && cmake .. \
     && cmake --build .
-
+    
 RUN cp $cgimap/build/openstreetmap-cgimap /usr/local/bin/ && rm -rf $cgimap
 
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local_libs.conf && ldconfig

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install -g svgo
 
 # Install openstreetmap-website
 RUN rm -rf $workdir/html
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=daefee44772d61c68b2b491d77a9b2658d0ad9cb
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=b6dda6c893e0e6f7c2c2f5d3c39727efe2b4080e
 
 RUN git clone https://github.com/OpenHistoricalMap/ohm-website.git $workdir \
     && cd $workdir \
@@ -16,7 +16,7 @@ RUN git clone https://github.com/OpenHistoricalMap/ohm-website.git $workdir \
 WORKDIR $workdir
 
 # change the echo here with a reason for changing the commithash
-RUN echo 'various date and daterange improvements, new translations'
+RUN echo 'iD version bump to our 2.29.3'
 RUN git fetch && rm -rf .git
 
 # Install Ruby packages

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/openhistoricalmap/cgimap:0.0.1-0.dev.git.2087.h29c3843
+FROM ghcr.io/openhistoricalmap/cgimap:0.0.1-0.dev.git.2389.h29c3843
 
 # Install Passenger
 RUN gem install passenger && passenger-install-apache2-module --auto

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/openhistoricalmap/cgimap:0.0.1-0.dev.git.2087.h94d548c
+FROM ghcr.io/openhistoricalmap/cgimap:0.0.1-0.dev.git.2087.h29c3843
 
 # Install Passenger
 RUN gem install passenger && passenger-install-apache2-module --auto

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/openhistoricalmap/cgimap:0.0.1-0.dev.git.2389.h29c3843
+FROM ghcr.io/openhistoricalmap/cgimap:0.0.1-0.dev.git.2393.h74d1139
 
 # Install Passenger
 RUN gem install passenger && passenger-install-apache2-module --auto

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -68,8 +68,8 @@
     </FilesMatch>
 
     # Redirect old map-style paths to their current locations
-    RedirectMatch 301 ^/map-styles/main/main\.json$ /map-styles/historical/historical.json
-    RedirectMatch 301 ^/map-styles/rail/rail\.json$ /map-styles/railway/railway.json
-    RedirectMatch 301 ^/map-styles/japanese_scroll/ohm-japanese-scroll-map\.json$ /map-styles/japanese_scroll/japanese_scroll.json
-
+    RewriteRule ^/map-styles/main/main\.json$ /map-styles/historical/historical.json [PT,L]
+    RewriteRule ^/map-styles/rail/rail\.json$ /map-styles/railway/railway.json [PT,L]
+    RewriteRule ^/map-styles/japanese_scroll/ohm-japanese-scroll-map\.json$ /map-styles/japanese_scroll/japanese_scroll.json [PT,L]
+    
  </VirtualHost>

--- a/images/web/config/settings.yml
+++ b/images/web/config/settings.yml
@@ -7,9 +7,9 @@ embed_server_url: "https://embed.openhistoricalmap.org/"
 #publisher_url: ""
 # The generator
 generator: "OpenHistoricalMap server"
-copyright_owner: "OpenHistoricalMap and contributors"
+copyright_owner: "OpenHistoricalMap is dedicated to the public domain except where otherwise noted."
 attribution_url: "http://www.openhistoricalmap.org/copyright"
-license_url: "http://opendatacommons.org/licenses/odbl/1-0/"
+license_url: "https://creativecommons.org/public-domain/cc0/"
 # Support email address
 support_email: "ohm-admins@googlegroups.com"
 # Sender addresses for emails

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: osm-seed
-    version: '0.1.0-n812.hc1b472b'
+    version: '0.1.0-n811.hbbe3b8f'
     repository: https://devseed.com/osm-seed-chart/

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -894,7 +894,7 @@ osm-seed:
     priorityClass: 'medium-priority'
     image:
       name: ghcr.io/openhistoricalmap/osmcha-frontend
-      tag: 4d6003e
+      tag: 4a2543f
 # ====================================================================================================
 # Variables for osmcha Api
 # ====================================================================================================

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -779,7 +779,7 @@ osm-seed:
       priorityClass: "medium-priority"
       image:
         name: ghcr.io/openhistoricalmap/osmcha-frontend
-        tag: 4d6003e
+        tag: 4a2543f
 # ====================================================================================================
 # Variables for osmcha Api, We hard code the container id.
 # ====================================================================================================


### PR DESCRIPTION
- Release new iD version
- Update license for xml outputs, rails/cgimap https://github.com/OpenHistoricalMap/issues/issues/448#issuecomment-2769291256
- Map-style redirects. https://github.com/OpenHistoricalMap/issues/issues/1005

cc. @danrademacher @erictheise @1ec5 