### PR TITLE
Run web and cgimap processes  in different containers 

### DIFF
--- a/.github/workflows/chartpress.yaml
+++ b/.github/workflows/chartpress.yaml
@@ -5,7 +5,7 @@ on:
       - 'main'
       - 'staging'
       - 'development'
-      - 'water_areas'
+      - 'service/cgimap'
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ images/data/
 data/
 images/.env
 images/tiler.yml
-values.dev.yaml
+values.dev.*.yaml
 values.osmcha.yaml
 secrets
 tegola

--- a/images/cgimap/Dockerfile
+++ b/images/cgimap/Dockerfile
@@ -1,36 +1,48 @@
-FROM ruby:3.3.0 AS builder
+Git add FROM ruby:3.3.0 AS builder
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV workdir=/var/www
 ENV CGIMAP_GITSHA=8ea707e10aeab5698e6859856111816d75354592
-RUN apt-get update && apt-get install -y \
-    build-essential cmake git-core curl file \
+ENV cgimap=/tmp/openstreetmap-cgimap
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git curl file \
     libxml2-dev libpqxx-dev libfcgi-dev zlib1g-dev libbrotli-dev \
     libboost-program-options-dev libfmt-dev libmemcached-dev libcrypto++-dev \
-    libargon2-dev libyajl-dev libapache2-mod-fcgid \
-    && rm -rf /var/lib/apt/lists/*
-ENV cgimap=/tmp/openstreetmap-cgimap
-RUN git clone -b master https://github.com/zerebubuth/openstreetmap-cgimap.git $cgimap \
-    && cd $cgimap \
-    && git checkout $CGIMAP_GITSHA \
-    && sed -i 's#OpenStreetMap and contributors#OpenHistoricalMap is dedicated to the public domain except where otherwise noted.#g' include/cgimap/output_formatter.hpp \
-    && sed -i 's#http://www.openstreetmap.org/copyright#https://www.openhistoricalmap.org/copyright#g' include/cgimap/output_formatter.hpp \
-    && sed -i 's#http://opendatacommons.org/licenses/odbl/1-0/#https://creativecommons.org/public-domain/cc0/#g' include/cgimap/output_formatter.hpp \
-    && mkdir build && cd build && cmake .. && cmake --build .
+    libargon2-dev libyajl-dev \
+ && rm -rf /var/lib/apt/lists/*
 
-FROM ruby:3.3.0
+RUN git clone https://github.com/zerebubuth/openstreetmap-cgimap.git $cgimap \
+ && cd $cgimap \
+ && git checkout $CGIMAP_GITSHA \
+ && sed -i 's#OpenStreetMap and contributors#OpenHistoricalMap is dedicated to the public domain except where otherwise noted.#g' include/cgimap/output_formatter.hpp \
+ && sed -i 's#http://www.openstreetmap.org/copyright#https://www.openhistoricalmap.org/copyright#g' include/cgimap/output_formatter.hpp \
+ && sed -i 's#http://opendatacommons.org/licenses/odbl/1-0/#https://creativecommons.org/public-domain/cc0/#g' include/cgimap/output_formatter.hpp \
+ && mkdir build && cd build && cmake .. && cmake --build .
+
+
+# -- Final image
+FROM ruby:3.3.0-slim
+
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y \
+
+# Add PostgreSQL official repo and install only required runtime libs and postgresql-client
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl gnupg && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
     libxml2 libpqxx-6.4 libfcgi zlib1g libbrotli1 \
     libboost-program-options1.74.0 libfmt-dev libmemcached11 libcrypto++8 \
     libargon2-1 libyajl2 libapache2-mod-fcgid postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get install -y postgresql-client
-
+# Copy built binary from builder
 COPY --from=builder /tmp/openstreetmap-cgimap/build/openstreetmap-cgimap /usr/local/bin/openstreetmap-cgimap
-RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local_libs.conf && ldconfig
+
+# Copy scripts and configure shared libs
 COPY *.sh /
-CMD [ "/start.sh" ]
+RUN chmod +x /*.sh && echo "/usr/local/lib" > /etc/ld.so.conf.d/local_libs.conf && ldconfig
+
+CMD ["/start.sh"]

--- a/images/cgimap/Dockerfile
+++ b/images/cgimap/Dockerfile
@@ -1,4 +1,4 @@
-Git add FROM ruby:3.3.0 AS builder
+FROM ruby:3.3.0 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV workdir=/var/www

--- a/images/cgimap/Dockerfile
+++ b/images/cgimap/Dockerfile
@@ -1,51 +1,36 @@
-FROM ruby:3.3.0
+FROM ruby:3.3.0 AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 ENV workdir=/var/www
-
-# Production OSM setup
-ENV RAILS_ENV=production
-
-# Install the openstreetmap-website dependencies
-RUN apt-get update \
-    && apt-get install -y \
-    libmagickwand-dev libxml2-dev libxslt1-dev \
-    apache2 apache2-dev build-essential git-core postgresql-client \
-    libpq-dev libsasl2-dev imagemagick libffi-dev libgd-dev libarchive-dev libbz2-dev curl \
-    default-jre-headless file gpg-agent libvips-dev locales software-properties-common tzdata unzip \
-    advancecomp gifsicle libjpeg-progs jhead jpegoptim optipng pngcrush pngquant \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install node
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y nodejs yarn && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install openstreetmap-cgimap requirements
-RUN apt-get update &&  apt-get -y install libxml2-dev libpqxx-dev libfcgi-dev zlib1g-dev libbrotli-dev \
-  libboost-program-options-dev libfmt-dev libmemcached-dev libcrypto++-dev \
-  libargon2-dev libyajl-dev cmake libapache2-mod-fcgid && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
-
-# Install cgimap v2.0.1
-ENV cgimap=/tmp/openstreetmap-cgimap
 ENV CGIMAP_GITSHA=8ea707e10aeab5698e6859856111816d75354592
+RUN apt-get update && apt-get install -y \
+    build-essential cmake git-core curl file \
+    libxml2-dev libpqxx-dev libfcgi-dev zlib1g-dev libbrotli-dev \
+    libboost-program-options-dev libfmt-dev libmemcached-dev libcrypto++-dev \
+    libargon2-dev libyajl-dev libapache2-mod-fcgid \
+    && rm -rf /var/lib/apt/lists/*
+ENV cgimap=/tmp/openstreetmap-cgimap
 RUN git clone -b master https://github.com/zerebubuth/openstreetmap-cgimap.git $cgimap \
     && cd $cgimap \
     && git checkout $CGIMAP_GITSHA \
     && sed -i 's#OpenStreetMap and contributors#OpenHistoricalMap is dedicated to the public domain except where otherwise noted.#g' include/cgimap/output_formatter.hpp \
     && sed -i 's#http://www.openstreetmap.org/copyright#https://www.openhistoricalmap.org/copyright#g' include/cgimap/output_formatter.hpp \
     && sed -i 's#http://opendatacommons.org/licenses/odbl/1-0/#https://creativecommons.org/public-domain/cc0/#g' include/cgimap/output_formatter.hpp \
-    && rm -rf .git \
-    && mkdir build \
-    && cd build \
-    && cmake .. \
-    && cmake --build .
-    
-RUN cp $cgimap/build/openstreetmap-cgimap /usr/local/bin/ && rm -rf $cgimap
+    && mkdir build && cd build && cmake .. && cmake --build .
 
+FROM ruby:3.3.0
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    libxml2 libpqxx-6.4 libfcgi zlib1g libbrotli1 \
+    libboost-program-options1.74.0 libfmt-dev libmemcached11 libcrypto++8 \
+    libargon2-1 libyajl2 libapache2-mod-fcgid postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y postgresql-client
+
+COPY --from=builder /tmp/openstreetmap-cgimap/build/openstreetmap-cgimap /usr/local/bin/openstreetmap-cgimap
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local_libs.conf && ldconfig
+COPY *.sh /
+CMD [ "/start.sh" ]

--- a/images/cgimap/liveness.sh
+++ b/images/cgimap/liveness.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+pgrep -f openstreetmap-cgimap > /dev/null
+cgimap_status=$?
+
+# Check PostgreSQL connection
+PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1;" > /dev/null 2>&1
+postgres_status=$?
+
+# Exit code logic
+if [ $cgimap_status -eq 0 ] && [ $postgres_status -eq 0 ]; then
+  echo "cgimap and PostgreSQL are healthy"
+  exit 0
+else
+  [ $cgimap_status -ne 0 ] && echo "cgimap not running" >&2
+  [ $postgres_status -ne 0 ] && echo "cannot connect to PostgreSQL" >&2
+  exit 1
+fi

--- a/images/cgimap/start.sh
+++ b/images/cgimap/start.sh
@@ -41,5 +41,7 @@ else
   psql -h $POSTGRES_HOST -U $POSTGRES_USER -c "SHOW enable_mergejoin;"
   psql -h $POSTGRES_HOST -U $POSTGRES_USER -c "SHOW enable_hashjoin;"
   # Start the cgimap service
-  exec openstreetmap-cgimap --port=8000 --instances=10
+  openstreetmap-cgimap --port=8000 --instances=10
+  # Keep container alive
+  tail -f /dev/null
 fi

--- a/images/cgimap/start.sh
+++ b/images/cgimap/start.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+export PGPASSWORD=$POSTGRES_PASSWORD
+export CGIMAP_HOST=$POSTGRES_HOST
+export CGIMAP_DBNAME=$POSTGRES_DB
+export CGIMAP_USERNAME=$POSTGRES_USER
+export CGIMAP_PASSWORD=$POSTGRES_PASSWORD
+export CGIMAP_OAUTH_HOST=$POSTGRES_HOST
+export CGIMAP_UPDATE_HOST=$POSTGRES_HOST
+# Export CGIMAP configuration
+# export CGIMAP_LOGFILE="/var/www/log/cgimap.log"
+export CGIMAP_LOGFILE="/dev/stdout"
+export CGIMAP_MEMCACHE=$OPENSTREETMAP_MEMCACHE_SERVERS
+# Average number of bytes/s to allow each client
+export CGIMAP_RATELIMIT="204800"
+# Maximum debt in MB to allow each client before rate limiting
+export CGIMAP_MAXDEBT="2048"  
+export CGIMAP_MAP_AREA="0.25"
+export CGIMAP_MAP_NODES="100000"
+export CGIMAP_MAX_WAY_NODES="2000"
+export CGIMAP_MAX_RELATION_MEMBERS="32000"
+# export CGIMAP_RATELIMIT_UPLOAD="true"
+export CGIMAP_MODERATOR_RATELIMIT="1048576"
+export CGIMAP_MODERATOR_MAXDEBT="2048"
+
+echo "Waiting for PostgreSQL to be ready..."
+until pg_isready -h "$POSTGRES_HOST" -p 5432; do
+  sleep 2
+done
+
+if [[ "$WEBSITE_STATUS" == "database_readonly" || "$WEBSITE_STATUS" == "api_readonly" ]]; then
+  export CGIMAP_DISABLE_API_WRITE="true"
+fi
+
+if [[ "$WEBSITE_STATUS" == "database_offline" || "$WEBSITE_STATUS" == "api_offline" ]]; then
+  echo "Website is $WEBSITE_STATUS. No action required for cgimap service."
+else
+  # PostgreSQL options to disable certain joins
+  export PGOPTIONS="-c enable_mergejoin=false -c enable_hashjoin=false"
+  # Display current PostgreSQL settings
+  psql -h $POSTGRES_HOST -U $POSTGRES_USER -c "SHOW enable_mergejoin;"
+  psql -h $POSTGRES_HOST -U $POSTGRES_USER -c "SHOW enable_hashjoin;"
+  # Start the cgimap service
+  exec openstreetmap-cgimap --port=8000 --instances=10
+fi

--- a/images/cgimap/start.sh
+++ b/images/cgimap/start.sh
@@ -8,8 +8,8 @@ export CGIMAP_PASSWORD=$POSTGRES_PASSWORD
 export CGIMAP_OAUTH_HOST=$POSTGRES_HOST
 export CGIMAP_UPDATE_HOST=$POSTGRES_HOST
 # Export CGIMAP configuration
-# export CGIMAP_LOGFILE="/var/www/log/cgimap.log"
-export CGIMAP_LOGFILE="/dev/stdout"
+export CGIMAP_LOGFILE="/var/log/cgimap.log"
+# export CGIMAP_LOGFILE="/dev/stdout"
 export CGIMAP_MEMCACHE=$OPENSTREETMAP_MEMCACHE_SERVERS
 # Average number of bytes/s to allow each client
 export CGIMAP_RATELIMIT="204800"
@@ -43,5 +43,5 @@ else
   # Start the cgimap service
   openstreetmap-cgimap --port=8000 --daemon --instances=10
   # Keep container alive
-  tail -f /dev/null
+  tail -f /var/log/cgimap.log
 fi

--- a/images/cgimap/start.sh
+++ b/images/cgimap/start.sh
@@ -41,7 +41,7 @@ else
   psql -h $POSTGRES_HOST -U $POSTGRES_USER -c "SHOW enable_mergejoin;"
   psql -h $POSTGRES_HOST -U $POSTGRES_USER -c "SHOW enable_hashjoin;"
   # Start the cgimap service
-  openstreetmap-cgimap --port=8000 --instances=10
+  openstreetmap-cgimap --port=8000 --daemon --instances=10
   # Keep container alive
   tail -f /dev/null
 fi

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -16,7 +16,7 @@ RUN git clone https://github.com/OpenHistoricalMap/ohm-website.git $workdir \
 WORKDIR $workdir
 
 # change the echo here with a reason for changing the commithash
-RUN echo 'map-styles version bump to 0.9.6'
+RUN echo 'map-styles version bump to 0.9.7'
 RUN git fetch && rm -rf .git
 
 # Install Ruby packages

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -1,111 +1,95 @@
-FROM ghcr.io/openhistoricalmap/cgimap:0.0.1-0.dev.git.2393.h74d1139
+FROM ruby:3.3-slim
 
-# Install Passenger
-RUN gem install passenger && passenger-install-apache2-module --auto
+ENV DEBIAN_FRONTEND=noninteractive \
+    workdir=/var/www
 
-# Install svgo required
-RUN npm install -g svgo
-
-# Install openstreetmap-website
-RUN rm -rf $workdir/html
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=fb2292b81faefb5ce7c704ddb0c57814e1c4cd7a
-
-RUN git clone https://github.com/OpenHistoricalMap/ohm-website.git $workdir \
-    && cd $workdir \
-    && git checkout $OPENHISTORICALMAP_WEBSITE_GITSHA
 WORKDIR $workdir
 
-# change the echo here with a reason for changing the commithash
-RUN echo 'map-styles version bump to 0.9.7'
-RUN git fetch && rm -rf .git
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git curl gnupg libarchive-dev \
+    zlib1g-dev libcurl4-openssl-dev \
+    apache2 apache2-dev libapache2-mod-passenger libapache2-mod-fcgid libapr1-dev libaprutil1-dev \
+    build-essential postgresql-client && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs libpq-dev libxml2-dev libyaml-dev && \
+    if ! command -v yarn >/dev/null 2>&1; then npm install -g yarn; fi && \
+    npm install -g svgo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Ruby packages
-RUN gem install bundler && bundle install
-
-# Configure database.yml
-RUN cp $workdir/config/example.database.yml $workdir/config/database.yml
-RUN touch $workdir/config/settings.local.yml
-RUN cp $workdir/config/example.storage.yml $workdir/config/storage.yml
-# Protect sensitive information
-RUN chmod 600 $workdir/config/database.yml
-
-RUN yarn install
-RUN bundle exec rake yarn:install
-
-# Generate RAILS_MASTER_KEY and SECRET_KEY_BASE during build
-RUN rm -f config/credentials.yml.enc
-RUN export RAILS_MASTER_KEY=$(openssl rand -hex 16) && \
-    export SECRET_KEY_BASE=$(rails secret) && \
-    echo $RAILS_MASTER_KEY > config/master.key && \
-    if [ ! -f config/credentials.yml.enc ]; then \
-        EDITOR="echo" RAILS_MASTER_KEY=$RAILS_MASTER_KEY rails credentials:edit; \
-    fi && \
-    RAILS_MASTER_KEY=$RAILS_MASTER_KEY rails runner " \
-        require 'active_support/encrypted_configuration'; \
-        require 'yaml'; \
-        creds = ActiveSupport::EncryptedConfiguration.new( \
-          config_path: 'config/credentials.yml.enc', \
-          key_path: 'config/master.key', \
-          env_key: 'RAILS_MASTER_KEY', \
-          raise_if_missing_key: true \
-        ); \
-        credentials = { secret_key_base: '${SECRET_KEY_BASE}' }; \
-        creds.write(credentials.to_yaml); \
-        puts 'Credentials configured correctly.'"
-RUN bundle exec rake i18n:js:export --trace
-RUN bundle exec rake assets:precompile
-
-# The rack interface requires a `tmp` directory to use openstreetmap-cgimap
-RUN ln -s /tmp /var/www/tmp
-
-# Add Apache configuration file
-ADD config/production.conf /etc/apache2/sites-available/production.conf
-RUN a2enmod headers setenvif proxy proxy_http proxy_fcgi fcgid rewrite lbmethod_byrequests
-RUN a2dissite 000-default
-RUN a2ensite production
-
-# Enable the Passenger Apache module and restart Apache
-RUN echo "ServerName $(cat /etc/hostname)" >> /etc/apache2/apache2.conf
-
-# Config passenger module
-RUN echo "LoadModule passenger_module $(passenger-config --root)/buildout/apache2/mod_passenger.so" > /etc/apache2/mods-available/passenger.load
-RUN echo "<IfModule mod_passenger.c>\n\
-    PassengerRoot $(passenger-config --root)\n\
-    PassengerRuby /usr/local/bin/ruby\n\
-</IfModule>" > /etc/apache2/mods-available/passenger.conf
+# Install Passenger
 RUN a2enmod passenger
 
-# Check installation
-RUN /usr/local/bundle/bin/passenger-config validate-install
-RUN /usr/local/bundle/bin/passenger-memory-stats
+# Clone OHM Website
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=fb2292b81faefb5ce7c704ddb0c57814e1c4cd7a
+RUN rm -rf $workdir/*
+RUN git clone https://github.com/OpenHistoricalMap/ohm-website.git $workdir && \
+    cd $workdir && git checkout $OPENHISTORICALMAP_WEBSITE_GITSHA && rm -rf .git
 
-# Config the virtual host apache2
+ 
+# Install Ruby/Node dependencies
+RUN gem install bundler && bundle install && \
+    yarn install && \
+    bundle exec rake yarn:install
+
+RUN cp config/example.database.yml config/database.yml && \
+    cp config/example.storage.yml config/storage.yml && \
+    touch config/settings.local.yml && \
+    chmod 600 config/database.yml
+
+RUN rm -f config/credentials.yml.enc && \
+    export RAILS_MASTER_KEY=$(openssl rand -hex 16) && \
+    export SECRET_KEY_BASE=$(bundle exec rails secret) && \
+    echo $RAILS_MASTER_KEY > config/master.key && \
+    EDITOR="echo" RAILS_MASTER_KEY=$RAILS_MASTER_KEY rails credentials:edit && \
+    RAILS_MASTER_KEY=$RAILS_MASTER_KEY rails runner "\
+      require 'active_support/encrypted_configuration'; \
+      require 'yaml'; \
+      creds = ActiveSupport::EncryptedConfiguration.new(\
+        config_path: 'config/credentials.yml.enc', \
+        key_path: 'config/master.key', \
+        env_key: 'RAILS_MASTER_KEY', \
+        raise_if_missing_key: true \
+      ); \
+      credentials = { secret_key_base: '$SECRET_KEY_BASE' }; \
+      creds.write(credentials.to_yaml); \
+      puts 'Credentials configured correctly.'"
+
+# Precompile assets
+RUN bundle exec rake i18n:js:export && \
+    bundle exec rake assets:precompile
+RUN ln -s /tmp /var/www/tmp
+
+# Apache config
+COPY config/production.conf /etc/apache2/sites-available/production.conf
+RUN a2enmod headers setenvif proxy proxy_http proxy_fcgi fcgid rewrite lbmethod_byrequests passenger && \
+    a2dissite 000-default && \
+    a2ensite production && \
+    echo "ServerName $(cat /etc/hostname)" >> /etc/apache2/apache2.conf
+
 RUN apache2ctl configtest
-
-# Set Permissions for www-data
 RUN chown -R www-data: $workdir
 
-# Prepare to set env variables & host map-styles publicly independent of the Rails app
-RUN mkdir -p $workdir/public/map-styles
+# Map styles
+RUN mkdir -p public/map-styles
 COPY update_map_styles.py $workdir/
 
-# Clone leaflet-ohm-timeslider-v2
+# Leaflet timeslider assets
 ENV LEAFLET_OHM_TIMESLIDER_V2=dd0acbdc9432fae6a4d09a17a4848c391e5064f0
-RUN git clone https://github.com/OpenHistoricalMap/leaflet-ohm-timeslider-v2.git $workdir/public/leaflet-ohm-timeslider-v2 \
-    && cd $workdir/public/leaflet-ohm-timeslider-v2 \
-    && git checkout dd0acbdc9432fae6a4d09a17a4848c391e5064f0 \
-    && rm -rf .git \
-    && chmod 777 -R assets/ \
-    && cp decimaldate.* $workdir/app/assets/javascripts/ \
-    && cp leaflet-ohm-timeslider.* $workdir/app/assets/javascripts/ \
-    && cp leaflet-ohm-timeslider.* $workdir/app/assets/stylesheets/ \
-    && cp assets/* $workdir/app/assets/images/
+RUN git clone https://github.com/OpenHistoricalMap/leaflet-ohm-timeslider-v2.git $workdir/public/leaflet-ohm-timeslider-v2 && \
+    cd $workdir/public/leaflet-ohm-timeslider-v2 && \
+    git checkout $LEAFLET_OHM_TIMESLIDER_V2 && \
+    rm -rf .git && \
+    chmod 777 -R assets/ && \
+    cp decimaldate.* $workdir/app/assets/javascripts/ && \
+    cp leaflet-ohm-timeslider.* $workdir/app/assets/javascripts/ && \
+    cp leaflet-ohm-timeslider.* $workdir/app/assets/stylesheets/ && \
+    cp assets/* $workdir/app/assets/images/
 
-# Add settings
-ADD config/settings.yml $workdir/config/
 
-COPY start.sh $workdir/
-COPY cgimap.sh $workdir/
-COPY liveness.sh $workdir/
+COPY config/settings.yml $workdir/config/
+COPY start.sh liveness.sh $workdir/
+RUN chmod +x $workdir/*.sh
 
-CMD $workdir/start.sh
+CMD ["./start.sh"]

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -19,20 +19,22 @@
 
     <Location />
         CGIPassAuth On
+        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
     </Location>
 
     # Proxying traffic to CGImap
     ProxyTimeout 1200
     RewriteCond %{REQUEST_URI} ^/api/0\.6/map
-    RewriteRule ^/api/0\.6/map(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
+    RewriteRule ^/api/0\.6/map(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+
     RewriteCond %{REQUEST_METHOD} ^(HEAD|GET)$
-    RewriteRule ^/api/0\.6/(node|way|relation|changeset)/[0-9]+(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
-    RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/history(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
-    RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/relations(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
-    RewriteRule ^/api/0\.6/node/[0-9]+/ways(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
-    RewriteRule ^/api/0\.6/(way|relation)/[0-9]+/full(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
-    RewriteRule ^/api/0\.6/(nodes|ways|relations)(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
-    RewriteRule ^/api/0\.6/changeset/[0-9]+/(upload|download)(\.json|\.xml)?$ fcgi://127.0.0.1:8000$0 [P]
+    RewriteRule ^/api/0\.6/(node|way|relation|changeset)/[0-9]+(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+    RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/history(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+    RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/relations(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+    RewriteRule ^/api/0\.6/node/[0-9]+/ways(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+    RewriteRule ^/api/0\.6/(way|relation)/[0-9]+/full(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+    RewriteRule ^/api/0\.6/(nodes|ways|relations)(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
+    RewriteRule ^/api/0\.6/changeset/[0-9]+/(upload|download)(\.json|\.xml)?$ fcgi://${CGIMAP_URL}:${CGIMAP_PORT}$0 [P]
 
     # Relax Apache security settings
     <Directory /var/www/public>

--- a/images/web/liveness.sh
+++ b/images/web/liveness.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This is a script for evaluating if openstreetmap-cgimap, apache2, and PostgreSQL are running in the container.
+# This is a script for evaluating if apache2 is running in the container and PostgreSQL is reachable. 
 check_process() {
     if ps aux | grep "$1" | grep -v grep > /dev/null; then
         return 0
@@ -8,29 +8,24 @@ check_process() {
     fi
 }
 
-# Check for openstreetmap-cgimap process
-check_process "/usr/local/bin/openstreetmap-cgimap"
-cgimap_status=$?
-
 # Check for apache2 process
 check_process "apache2"
 apache_status=$?
 
 # Check PostgreSQL connection
 check_postgres() {
-    PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB -c "SELECT 1;" > /dev/null 2>&1
+    PGPASSWORD=$POSTGRES_PASSWORD psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1;" > /dev/null 2>&1
     return $?
 }
 
 check_postgres
 postgres_status=$?
 
-if [ $cgimap_status -eq 0 ] && [ $apache_status -eq 0 ] && [ $postgres_status -eq 0 ]; then
-    echo "All services (openstreetmap-cgimap, apache2, PostgreSQL) are running."
+if [ $apache_status -eq 0 ] && [ $postgres_status -eq 0 ]; then
+    echo "Apache and PostgreSQL are running."
     exit 0
 else
-    [ $cgimap_status -ne 0 ] && echo "openstreetmap-cgimap is not running!" 1>&2
-    [ $apache_status -ne 0 ] && echo "apache2 is not running!" 1>&2
-    [ $postgres_status -ne 0 ] && echo "Failed to connect to PostgreSQL!" 1>&2
+    [ $apache_status -ne 0 ] && echo "apache2 is not running!" >&2
+    [ $postgres_status -ne 0 ] && echo "Failed to connect to PostgreSQL!" >&2
     exit 1
 fi

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -124,9 +124,6 @@ setup_production() {
   echo "Running database migrations..."
   time bundle exec rails db:migrate
 
-  echo "Running cgimap..."
-  ./cgimap.sh
-
   echo "Starting Apache server..."
   apachectl -k start -DFOREGROUND &
 

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -124,6 +124,11 @@ setup_production() {
   echo "Running database migrations..."
   time bundle exec rails db:migrate
 
+  if [ "$EXTERNAL_CGIMAP" == "false" ]; then
+    echo "Running cgimap..."
+    ./cgimap.sh
+  fi
+
   echo "Starting Apache server..."
   apachectl -k start -DFOREGROUND &
 

--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: osm-seed
-    version: '0.0.1-0.dev.git.1.h37af320'
+    version: '0.1.0-0.dev.git.975.h2e179bd'
     repository: https://devseed.com/osm-seed-chart/

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -171,8 +171,6 @@ osm-seed:
         RAILS_STORAGE_REGION: us-east-1
         RAILS_STORAGE_BUCKET: ohm-website-staging
         EXTERNAL_CGIMAP: true
-        # API_TIMEOUT: 600
-        # WEB_TIMEOUT: 600
       resources:
         enabled: true
         requests:
@@ -208,8 +206,8 @@ osm-seed:
     cgimap:
       enabled: true
       image:
-        name: ghcr.io/openhistoricalmap/cgimap
-        tag: 0.0.1-0.dev.git.2427.h1c6a803
+        name: ""
+        tag: ""
       priorityClass: "low-priority"
       resources:
         enabled: false

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -170,6 +170,7 @@ osm-seed:
         RAILS_STORAGE_SERVICE: s3
         RAILS_STORAGE_REGION: us-east-1
         RAILS_STORAGE_BUCKET: ohm-website-staging
+        EXTERNAL_CGIMAP: true
         # API_TIMEOUT: 600
         # WEB_TIMEOUT: 600
       resources:
@@ -199,6 +200,26 @@ osm-seed:
         label_key: nodegroup_type
         label_value: web_medium
       resources:
+        enabled: false
+
+    # ====================================================================================================
+    # Cgimap
+    # ====================================================================================================
+    cgimap:
+      enabled: true
+      image:
+        name: ghcr.io/openhistoricalmap/cgimap
+        tag: 0.0.1-0.dev.git.2427.h1c6a803
+      priorityClass: "low-priority"
+      resources:
+        enabled: false
+        requests:
+          memory: '20Gi'
+          cpu: '8'
+        limits:
+          memory: '24Gi'
+          cpu: '10'
+      nodeSelector:
         enabled: false
     # ====================================================================================================
     # Variables for osm-seed for osmosis, this configuration os to get the planet dump files from apidb


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/997 and https://github.com/OpenHistoricalMap/issues/issues/791

This PR splits the web and cgimap into different containers. This is because it’s better to handle these processes separately and keep the web container lighter, allowing services to start faster under high user concurrency.
