### PR TITLE
Update osm-seed version and add necessary resource requests for web and cgimap pods

### DIFF
--- a/ohm/requirements.yaml
+++ b/ohm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: osm-seed
-    version: '0.1.0-0.dev.git.982.h31aa902'
+    version: '0.1.0-0.dev.git.983.h15e362a'
     repository: https://devseed.com/osm-seed-chart/

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -165,8 +165,8 @@ osm-seed:
       enabled: true
       requests:
         enabled: true
-        memory: "3Gi"
-        cpu: "600m"
+        memory: "2Gi"
+        cpu: "450m"
       limits:
         enabled: false
         memory: "4Gi"
@@ -175,7 +175,8 @@ osm-seed:
       enabled: true
       minReplicas: 1
       maxReplicas: 10
-      cpuUtilization: 50
+      cpuUtilization: 70
+      memoryUtilization: 70
     sharedMemorySize: 512Mi
     livenessProbeExec: true
   # ====================================================================================================
@@ -213,7 +214,7 @@ osm-seed:
       requests:
         enabled: true
         memory: "2Gi"
-        cpu: "600m"
+        cpu: "450m"
       limits:
         enabled: false
         memory: "4Gi"


### PR DESCRIPTION
According to the latest evaluation after deploying separate containers- https://github.com/OpenHistoricalMap/ohm-deploy/pull/517 for cgimap and web, I am reducing the resources for the cgimap and web pods to avoid scaling up the nodes too quickly.
