### PR TITLE
Hotfix: Week 24 – Update ohm-website production release

### DIFF
--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
 RUN a2enmod passenger
 
 # Clone OHM Website
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=be0da199193ed59c17cd1728876642ed12b2213f
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=4bd56d63574d8f92ed99f17e487a41fa042ebfeb
 RUN rm -rf $workdir/* && \
     git clone https://github.com/OpenHistoricalMap/ohm-website.git $workdir && \
     cd $workdir && \

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -117,6 +117,18 @@ setup_production() {
   find /var/www/node_modules/@openhistoricalmap/map-styles/dist/ -type f -name "*.json" -exec sed -i.bak "s|vtiles.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" {} +
   find /var/www/node_modules/@openhistoricalmap/map-styles/dist/ -type f -name "*.json" -exec sed -i.bak "s|vtiles.staging.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" {} +
 
+  # Replace URLs in the public directory
+  find "/var/www/public" -type f | while read -r file; do
+    echo "Updating $file"
+    sed -i.bak \
+      -e "s|openhistoricalmap.github.io|${SERVER_URL}|g" \
+      -e "s|http://localhost:8888|https://${SERVER_URL}/map-styles|g" \
+      -e "s|www.openhistoricalmap.org|${SERVER_URL}|g" \
+      -e "s|https://vtiles.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" \
+      -e "s|https://vtiles.staging.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" \
+      "$file"
+  done
+
   echo "Waiting for PostgreSQL to be ready..."
   until pg_isready -h "$POSTGRES_HOST" -p 5432; do
     sleep 2

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -124,8 +124,8 @@ setup_production() {
       -e "s|openhistoricalmap.github.io|${SERVER_URL}|g" \
       -e "s|http://localhost:8888|https://${SERVER_URL}/map-styles|g" \
       -e "s|www.openhistoricalmap.org|${SERVER_URL}|g" \
-      -e "s|https://vtiles.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" \
-      -e "s|https://vtiles.staging.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" \
+      -e "s|vtiles.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" \
+      -e "s|vtiles.staging.openhistoricalmap.org|vtiles.${SERVER_URL_}|g" \
       "$file"
   done
 


### PR DESCRIPTION
This PR includes the following updates:
- The gitsha for the ohm-website repository has been updated from staging branch

- A script section was added to replace the production vector tile URLs (vtiles) with the staging ones. This is necessary because the map style JSON files include production URLs by default, which caused staging deployments to still load tiles from production.


cc. @1ec5 @danrademacher 