### PR TITLE
Update docker image for tiler-cache and imposm - hetzner config

### DIFF
--- a/hetzner/README.md
+++ b/hetzner/README.md
@@ -11,12 +11,13 @@ Ensure you are using the correct Docker images for production deployment, https:
 
 ```sh
 docker compose -f hetzner/tiler.production.yml up -d
+# docker compose -f hetzner/tiler.production.yml up db_production -d --force-recreate
 # docker compose -f hetzner/tiler.production.yml up imposm_production -d --force-recreate
 # docker compose -f hetzner/tiler.production.yml up tiler_production -d --force-recreate
 # docker compose -f hetzner/tiler.production.yml up tiler_sqs_cleaner_production -d --force-recreate
 # docker compose -f hetzner/tiler.production.yml up tile_global_seeding_production -d --force-recreate
 # docker compose -f hetzner/tiler.production.yml up tile_coverage_seeding_production -d --force-recreate
-# docker compose -f hetzner/tiler.production.yml up tiler_s3_cleaner_production -d --force-recreate
+# docker compose -f hetzner/tiler.production.yml run tiler_s3_cleaner_production python delete_s3_tiles.py
 # docker compose -f hetzner/tiler.production.yml up tiler_monitor_production -d --force-recreate 
 ```
 

--- a/hetzner/tiler.production.yml
+++ b/hetzner/tiler.production.yml
@@ -63,7 +63,7 @@ services:
       - tiler_network_production
 
   tiler_sqs_cleaner_production:
-    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2669.h101f906
+    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2675.h588af58
     env_file:
       - .env.production
     restart: always
@@ -71,7 +71,7 @@ services:
       - tiler_network_production_production
 
   tiler_s3_cleaner_production:
-    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2669.h101f906
+    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2675.h588af58
     env_file:
       - .env.production
     networks:

--- a/hetzner/tiler.production.yml
+++ b/hetzner/tiler.production.yml
@@ -68,14 +68,14 @@ services:
       - .env.production
     restart: always
     networks:
-      - tiler_network_production_production
+      - tiler_network_production
 
   tiler_s3_cleaner_production:
     image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2675.h588af58
     env_file:
       - .env.production
     networks:
-      - tiler_network_production_production
+      - tiler_network_production
 
   tile_global_seeding_production:
       image: ghcr.io/openhistoricalmap/tiler-server:0.0.1-0.dev.git.2669.h101f906
@@ -152,5 +152,5 @@ volumes:
     driver: local
     name: tiler_imposm_25_06_2025_production
 networks:
-  tiler_network:
+  tiler_network_production:
     driver: bridge

--- a/hetzner/tiler.staging.yml
+++ b/hetzner/tiler.staging.yml
@@ -97,7 +97,7 @@ networks:
 volumes:
   tiler_staging_pgdata:
     driver: local
-    name: tiler_db_25_06_2025_production
+    name: tiler_db_26_06_2025
   tiler_staging_imposmdata:
     driver: local
-    name: tiler_imposm_25_06_2025_production
+    name: tiler_imposm_26_06_2025

--- a/hetzner/tiler.staging.yml
+++ b/hetzner/tiler.staging.yml
@@ -56,7 +56,7 @@ services:
       - tiler_network_staging
 
   tiler_sqs_cleaner_staging:
-    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2669.h101f906
+    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2675.h588af58
     env_file:
       - .env.staging
     restart: always
@@ -69,7 +69,7 @@ services:
       - tiler_network_staging
 
   tiler_s3_cleaner_staging:
-    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2669.h101f906
+    image: ghcr.io/openhistoricalmap/tiler-cache:0.0.1-0.dev.git.2675.h588af58
     env_file:
       - .env.staging
     networks:


### PR DESCRIPTION
This PR only updates the Docker images for Hetzner and the README.