### PR TITLE
Set e-mail sender to noreply

### DIFF
--- a/images/web/config/settings.yml
+++ b/images/web/config/settings.yml
@@ -15,7 +15,7 @@ legal_email: "legal@openhistoricalmap.org"
 # Support email address
 support_email: "admin@openhistoricalmap.org"
 # Sender addresses for emails
-email_from: "OpenHistoricalMap <admin@openhistoricalmap.org>"
+email_from: "OpenHistoricalMap <web@noreply.openhistoricalmap.org>"
 email_return_path: "bounces@openhistoricalmap.org"
 
 # API version


### PR DESCRIPTION
As a followup to #561, each e-mail we send out needs to have a bogus e-mail address in the From: header too, not just Reply-To:.

Fixes OpenHistoricalMap/issues#1001.