### PR TITLE
replacing googlegroups email addresses with openhistoricalmap.org addresses

### DIFF
--- a/images/web/config/settings.local.yml
+++ b/images/web/config/settings.local.yml
@@ -3,9 +3,9 @@ embed_server_url: "https://embed.openhistoricalmap.org/"
 generator: "OpenHistoricalMap server"
 copyright_owner: "OpenHistoricalMap and contributors"
 attribution_url: "http://www.openhistoricalmap.org/copyright"
-support_email: "ohm-admins@googlegroups.com"
-email_from: "OpenHistoricalMap <ohm-admins@googlegroups.com>"
-email_return_path: "ohm-admins@googlegroups.com"
+support_email: "admin@openhistoricalmap.org"
+email_from: "OpenHistoricalMap <web@noreply.openhistoricalmap.org>"
+email_return_path: "bounces@openhistoricalmap.org"
 max_number_of_nodes: 100000
 api_timeout: 600
 web_timeout: 600

--- a/values.development.template.yaml
+++ b/values.development.template.yaml
@@ -8,7 +8,7 @@ osm-seed:
 
   domain: staging.openhistoricalmap.org
 
-  adminEmail: ohm-admins@googlegroups.com
+  adminEmail: admin@openhistoricalmap.org
 
   db:
     enabled: false
@@ -109,8 +109,8 @@ osm-seed:
       TM_SECRET: {{DEVELOPMENT_TM_API_SECRET}}
       # TM_CONSUMER_KEY: {{STAGING_TM_API_CONSUMER_KEY}}
       # TM_CONSUMER_SECRET: {{STAGING_TM_API_CONSUMER_SECRET}}
-      TM_EMAIL_FROM_ADDRESS: ohm-admins@googlegroups.com
-      TM_EMAIL_CONTACT_ADDRESS: ohm-admins@googlegroups.com
+      TM_EMAIL_FROM_ADDRESS: web@noreply.openhistoricalmap.org
+      TM_EMAIL_CONTACT_ADDRESS: admin@openhistoricalmap.org
       TM_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
       TM_SMTP_PORT: 25
       TM_SMTP_USER: {{MAILER_USERNAME}}

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -47,7 +47,7 @@ osm-seed:
 
   # Admin Email address used when generating Lets Encrypt certificates.
   # You will be notified of expirations, etc. on this email address.
-  adminEmail: ohm-admins@googlegroups.com
+  adminEmail: admin@openhistoricalmap.org
 
   # ====================================================================================================
   # Variables for osm-seed database
@@ -142,7 +142,7 @@ osm-seed:
       OSM_id_key: {{PRODUCTION_ID_APPLICATION}}
       OAUTH_CLIENT_ID: {{PRODUCTION_OAUTH_CLIENT_ID}}
       OAUTH_KEY: {{PRODUCTION_OAUTH_KEY}}
-      MAILER_FROM: ohm-admins@googlegroups.com
+      MAILER_FROM: web@noreply.penhistoricalmap.org
       NOMINATIM_URL: nominatim.openhistoricalmap.org
       OVERPASS_URL: overpass-api.openhistoricalmap.org
       NEW_RELIC_LICENSE_KEY: 'none'
@@ -710,8 +710,8 @@ osm-seed:
       ID_EDITOR_URL: https://www.openhistoricalmap.org/edit?editor=id
       POTLATCH2_EDITOR_URL: https://www.openhistoricalmap.org/edit?editor=potlatch2
       TM_SECRET: {{PRODUCTION_TM_API_SECRET}}
-      TM_EMAIL_FROM_ADDRESS: ohm-admins@googlegroups.com
-      TM_EMAIL_CONTACT_ADDRESS: ohm-admins@googlegroups.com
+      TM_EMAIL_FROM_ADDRESS: web@noreply.openhistoricalmap.org
+      TM_EMAIL_CONTACT_ADDRESS: admin@openhistoricalmap.org
       TM_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
       TM_SMTP_PORT: 25
       TM_SMTP_USER: {{MAILER_USERNAME}}

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -54,7 +54,7 @@ osm-seed:
   
     # Admin Email address used when generating Lets Encrypt certificates.
     # You will be notified of expirations, etc. on this email address.
-    adminEmail: ohm-admins@googlegroups.com
+    adminEmail: admin@openhistoricalmap.org
     # ====================================================================================================
     # ====================================================================================================
     # ==================================Pods Configurations===============================================
@@ -153,7 +153,7 @@ osm-seed:
         OSM_id_key: {{STAGING_ID_APPLICATION}}
         OAUTH_CLIENT_ID: {{STAGING_OAUTH_CLIENT_ID}}
         OAUTH_KEY: {{STAGING_OAUTH_KEY}}
-        MAILER_FROM: ohm-admins@googlegroups.com
+        MAILER_FROM: web@noreply.openhistoricalmap.org
         NOMINATIM_URL: nominatim.staging.openhistoricalmap.org
         OVERPASS_URL: overpass-api.staging.openhistoricalmap.org	
         NEW_RELIC_LICENSE_KEY: "none"
@@ -637,7 +637,7 @@ osm-seed:
         ID_EDITOR_URL: https://staging.openhistoricalmap.org/edit?editor=id
         POTLATCH2_EDITOR_URL: https://staging.openhistoricalmap.org/edit?editor=potlatch2
         TM_SECRET: {{STAGING_TM_API_SECRET}}
-        TM_EMAIL_FROM_ADDRESS: ohm-admins@googlegroups.com
+        TM_EMAIL_FROM_ADDRESS: web@noreply.openhistoricalmap.org
         TM_SMTP_HOST: email-smtp.us-east-1.amazonaws.com
         TM_SMTP_PORT: 25
         TM_SMTP_USER: {{MAILER_USERNAME}}
@@ -655,7 +655,7 @@ osm-seed:
         TM_REDIRECT_URI: https://tasks.staging.openhistoricalmap.org/authorized
         TM_SCOPE: 'read_prefs write_api'
         # Add extra info
-        TM_EMAIL_CONTACT_ADDRESS: ohm-admins@googlegroups.com
+        TM_EMAIL_CONTACT_ADDRESS: admin@openhistoricalmap.org
         TM_ORG_FB: https://www.facebook.com/openhistoricalmap
         TM_ORG_INSTAGRAM: https://www.openhistoricalmap.org
         TM_ORG_TWITTER: https://x.com/OpenHistoricalMap


### PR DESCRIPTION
just continuing replacements started in https://github.com/OpenHistoricalMap/ohm-deploy/pull/602/commits, following the same pattern (I think).

Not sure how to test