### PR TITLE
Moving Minute/Changeset replication pods  to utils node group

### DIFF
--- a/images/tiler-imposm/start.sh
+++ b/images/tiler-imposm/start.sh
@@ -26,6 +26,14 @@ TRACKING_FILE="$WORKDIR/uploaded_files.log"
 # Create config map for imposm
 python build_imposm3_config.py
 
+# Upload compiled imposm config to S3 for the tiler-monitor to read
+if [ -n "$AWS_S3_BUCKET" ]; then
+    log_message "Uploading imposm3.json to S3..."
+    aws s3 cp ./config/imposm3.json "${AWS_S3_BUCKET}/${BUCKET_IMPOSM_FOLDER}/imposm3.json" --acl public-read && \
+        log_message "imposm3.json uploaded to S3 successfully." || \
+        log_message "Warning: Failed to upload imposm3.json to S3. Monitor will use cached version."
+fi
+
 # Create config file for imposm
 cat <<EOF >"$WORKDIR/config.json"
 {

--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -339,11 +339,11 @@ osm-seed:
     nodeSelector:
       enabled: false
       label_key: nodegroup_type
-      label_value: web_helpers_medium
+      label_value: utils
     nodeAffinity:
       enabled: true
       key: "nodegroup_type"
-      values: ["web"]
+      values: ["utils"]
   # ====================================================================================================
   # Variables for osm-seed to pupulate the apidb
   # ====================================================================================================
@@ -755,11 +755,11 @@ osm-seed:
     nodeSelector:
       enabled: false
       label_key: nodegroup_type
-      label_value: web
+      label_value: utils
     nodeAffinity:
       enabled: true
       key: "nodegroup_type"
-      values: ["database"] 
+      values: ["utils"] 
   # ====================================================================================================
   # Variables for Tasking Manager API
   # ====================================================================================================
@@ -820,11 +820,11 @@ osm-seed:
     nodeSelector:
       enabled: false
       label_key: nodegroup_type
-      label_value: web
+      label_value: utils
     nodeAffinity:
       enabled: true
       key: "nodegroup_type"
-      values: ["web"] 
+      values: ["utils"] 
  # ====================================================================================================
   # Variables for nominatim api
   # ====================================================================================================
@@ -1069,11 +1069,11 @@ osm-seed:
     nodeSelector:
       enabled: false
       label_key: nodegroup_type
-      label_value: web
+      label_value: utils
     nodeAffinity:
       enabled: true
       key: "nodegroup_type"
-      values: ["web"]
+      values: ["utils"]
 # ====================================================================================================
 # Variables for osmcha web
 # ====================================================================================================


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/1327 and https://github.com/OpenHistoricalMap/ohm-deployment/pull/15
Moving pods to nodegroup_type=utils 

- Minute replication 
- Changeset replication 
- TM db
- TM api