### PR TITLE
Set memcached pods on stable nodes, not autoscaling ones

### DIFF
--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -208,11 +208,11 @@ osm-seed:
     nodeSelector:
       enabled: false
       label_key: nodegroup_type
-      label_value: web_helpers_medium
+      label_value: utils
     nodeAffinity:
       enabled: true
       key: "nodegroup_type"
-      values: ["web"]
+      values: ["utils"]
     # ====================================================================================================
     # Cgimap
     # ====================================================================================================


### PR DESCRIPTION
This issue was reported on Slack (https://osmus.slack.com/archives/C0A71EJRVC0/p1776098665404839). Login sessions expire whenever Memcached restarts on the autoscaling nodes. The solution is to move the Memcached pods to stable nodes.