### PR TITLE
Tiler updates and add attributes 

### DIFF
--- a/.github/workflows/chartpress.yaml
+++ b/.github/workflows/chartpress.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
       - 'staging'
-      - 'martin_vtiles'
+      - 'req_fresh_tiles'
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -71,7 +71,7 @@ jobs:
           OHM_SLACK_WEBHOOK_URL: ${{ secrets.OHM_SLACK_WEBHOOK_URL }}
       ################ Staging secrets ################ 
       - name: Staging - substitute secrets
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/martin_vtiles'
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/req_fresh_tiles'
         uses: bluwy/substitute-string-action@v1
         with:
           _input-file: 'values.staging.template.yaml'
@@ -189,14 +189,14 @@ jobs:
           PRODUCTION_OPENSTREETMAP_AUTH_SECRET: ${{ secrets.PRODUCTION_OPENSTREETMAP_AUTH_SECRET }}
           
       - name: AWS Credentials
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/martin_vtiles'
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/req_fresh_tiles'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Setup Kubectl and Helm Dependencies
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/martin_vtiles'
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/req_fresh_tiles'
         run: |
           sudo pip install awscli --ignore-installed six
           sudo curl -L -o /usr/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.7/2020-07-08/bin/linux/amd64/kubectl
@@ -210,22 +210,22 @@ jobs:
           helm version
 
       - name: Update kube-config staging
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/martin_vtiles'
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/req_fresh_tiles'
         run: aws eks --region us-east-1 update-kubeconfig --name osmseed-staging
       - name: Update kube-config prod
         if: github.ref == 'refs/heads/main'
         run: aws eks --region us-east-1 update-kubeconfig --name osmseed-production-v2
       - name: Add Helm repository
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/martin_vtiles'
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/req_fresh_tiles'
         run: |
           helm repo add osm-seed https://osm-seed.github.io/osm-seed-chart/
           helm repo update
       - name: Install helm dependencies for
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/martin_vtiles'
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/req_fresh_tiles'
         run: cd ohm && helm dep up
       # Staging
       - name: Staging - helm deploy
-        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/martin_vtiles'
+        if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/req_fresh_tiles'
         run: helm upgrade --install staging --wait ohm/ -f values.staging.yaml -f ohm/values.yaml
       # Production
       - name: Production - helm deploy

--- a/compose/tiler.yml
+++ b/compose/tiler.yml
@@ -72,24 +72,24 @@ services:
   #     - ohm_network
 
 
-  tiler-monitor:
-    image: rub21/tiler-monitor:v2
-    build:
-      context: ../images/tiler-monitor
-      dockerfile: Dockerfile
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ../hetzner:/app/hetzner
-      - tiler_monitor_data:/data
-    ports:
-      - "8001:8001"
-    environment:
-      - TILER_MONITORING_DOCKER_CONFIG_ENVIRONMENT=staging
-    env_file:
-      - ../envs/.env.tiler
-    restart: always
-    networks:
-      - ohm_network
+  # tiler-monitor:
+  #   image: rub21/tiler-monitor:v2
+  #   build:
+  #     context: ../images/tiler-monitor
+  #     dockerfile: Dockerfile
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #     - ../hetzner:/app/hetzner
+  #     - tiler_monitor_data:/data
+  #   ports:
+  #     - "8001:8001"
+  #   environment:
+  #     - TILER_MONITORING_DOCKER_CONFIG_ENVIRONMENT=staging
+  #   env_file:
+  #     - ../envs/.env.tiler
+  #   restart: always
+  #   networks:
+  #     - ohm_network
 
 networks:
   ohm_network:
@@ -98,12 +98,12 @@ networks:
 volumes:
   tiler_pgdata:
     driver: local
-    name: tiler_db
+    name: tiler_db_1704
 
   tiler_imposm_data:
     driver: local
-    name: tiler_imposm
+    name: tiler_imposm_1704
 
   tiler_monitor_data:
     driver: local
-    name: tiler_monitor
+    name: tiler_monitor_1704

--- a/hetzner/osmcha/osmcha.production.yml
+++ b/hetzner/osmcha/osmcha.production.yml
@@ -4,10 +4,10 @@ services:
     container_name: osmcha_ohmx_adiff
     environment:
       - API_URL=https://api.${OHM_DOMAIN}
-      - PLANET_PBF_URL=https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260408_0307.osm.pbf
+      - PLANET_PBF_URL=https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260418_0301.osm.pbf
       - MINUTE_REPLICATION_URL=https://planet.openhistoricalmap.org/?prefix=replication/minute/
       # Add OSMX_INITIAL_SEQNUM to start from a specific sequence number
-      # - OSMX_INITIAL_SEQNUM=1900000
+      - OSMX_INITIAL_SEQNUM=1900000
       - AWS_S3_BUCKET=planet.openhistoricalmap.org
     env_file:
       - ./.env.osmcha

--- a/hetzner/taginfo/taginfo.base.yml
+++ b/hetzner/taginfo/taginfo.base.yml
@@ -5,6 +5,16 @@ services:
     env_file:
       - ./.env.taginfo
     restart: always
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        set -ex
+        while true; do
+          rm -rf /usr/src/app/data/*.db
+          /usr/src/app/start.sh
+          sleep 270000
+        done
     networks:
       - ohm_network
 

--- a/hetzner/taginfo/taginfo.production.yml
+++ b/hetzner/taginfo/taginfo.production.yml
@@ -15,19 +15,11 @@ services:
       - -lc
       - |
         set -ex
-        echo "#!/bin/bash
-        rm -rf /usr/src/app/data/*
-        /usr/src/app/start.sh
-        sleep 7200
-        # restart web container
-        curl -v -X POST --unix-socket /var/run/docker.sock http://localhost/v1.41/containers/taginfo_web/restart" > /run_task.sh
-        chmod +x /run_task.sh
-        /run_task.sh
-        # 2. Set cron: Run every 3 days at 3:00 AM
-        echo "0 8 */3 * * /run_task.sh >> /var/log/taginfo-cron.log 2>&1" | crontab -
-        
-        touch /var/log/taginfo-cron.log
-        cron -f
+        while true; do
+          rm -rf /usr/src/app/data/*
+          /usr/src/app/start.sh
+          sleep 259200
+        done
     env_file:
       - ./.env.taginfo
     networks:

--- a/hetzner/tiler/tiler.production.yml
+++ b/hetzner/tiler/tiler.production.yml
@@ -138,7 +138,7 @@ services:
 
   tiler_server_martin:
     container_name: tiler_server_martin
-    image:  ghcr.io/openhistoricalmap/tiler-server-martin:0.0.1-0.dev.git.3374.h513ba86f
+    image: ghcr.io/openhistoricalmap/tiler-server-martin:0.0.1-0.dev.git.3344.h09bfac2f
     restart: always
     environment:
       - OHM_DOMAIN=${OHM_DOMAIN:-openhistoricalmap.org}
@@ -162,7 +162,7 @@ volumes:
     name: tiler_monitor_data_v3
   tiler_martin_nginx_cache:
     driver: local
-    name: tiler_martin_nginx_cache
+    name: tiler_martin_nginx_cache_v1
 networks:
   ohm_network:
     external: true

--- a/hetzner/tiler/tiler.production.yml
+++ b/hetzner/tiler/tiler.production.yml
@@ -121,7 +121,7 @@ services:
 
   tiler_monitor:
     container_name: tiler_monitor
-    image: ghcr.io/openhistoricalmap/tiler-monitor:0.0.1-0.dev.git.3364.hd63ad03e
+    image: ghcr.io/openhistoricalmap/tiler-monitor:0.0.1-0.dev.git.3348.h4fbb83d8
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # - ../../images/tiler-monitor:/app
@@ -144,6 +144,8 @@ services:
       - OHM_DOMAIN=${OHM_DOMAIN:-openhistoricalmap.org}
     env_file:
       - .env.tiler
+    ports:
+      - "3030:80"
     volumes:
       - tiler_martin_nginx_cache:/var/cache/nginx
     networks:

--- a/hetzner/tiler/tiler.production.yml
+++ b/hetzner/tiler/tiler.production.yml
@@ -18,7 +18,7 @@ services:
 
   tiler_imposm:
     container_name: tiler_imposm
-    image: ghcr.io/openhistoricalmap/tiler-imposm:0.0.1-0.dev.git.3374.h513ba86f
+    image: ghcr.io/openhistoricalmap/tiler-imposm:0.0.1-0.dev.git.3356.h880c9a8b
     volumes:
       - tiler_imposm_data:/mnt/data
     env_file:
@@ -138,7 +138,7 @@ services:
 
   tiler_server_martin:
     container_name: tiler_server_martin
-    image: ghcr.io/openhistoricalmap/tiler-server-martin:0.0.1-0.dev.git.3344.h09bfac2f
+    image: ghcr.io/openhistoricalmap/tiler-server-martin:0.0.1-0.dev.git.3355.hf7b796e6
     restart: always
     environment:
       - OHM_DOMAIN=${OHM_DOMAIN:-openhistoricalmap.org}
@@ -155,16 +155,16 @@ services:
 volumes:
   tiler_pgdata:
     driver: local
-    name: tiler_db
+    name: tiler_db_1704
   tiler_imposm_data:
     driver: local
-    name: tiler_imposm
+    name: tiler_imposm_1704
   tiler_monitor_data:
     driver: local
-    name: tiler_monitor_data_v3
+    name: tiler_monitor_1704
   tiler_martin_nginx_cache:
     driver: local
-    name: tiler_martin_nginx_cache_v1
+    name: tiler_martin_nginx_cache_1704
 networks:
   ohm_network:
     external: true

--- a/hetzner/tiler/tiler.production.yml
+++ b/hetzner/tiler/tiler.production.yml
@@ -138,7 +138,7 @@ services:
 
   tiler_server_martin:
     container_name: tiler_server_martin
-    image: ghcr.io/openhistoricalmap/tiler-server-martin:0.0.1-0.dev.git.3355.hf7b796e6
+    image: ghcr.io/openhistoricalmap/tiler-server-martin:0.0.1-0.dev.git.3357.he67b0015
     restart: always
     environment:
       - OHM_DOMAIN=${OHM_DOMAIN:-openhistoricalmap.org}

--- a/images/tiler-imposm/config/layers/street_multilines.json
+++ b/images/tiler-imposm/config/layers/street_multilines.json
@@ -114,6 +114,11 @@
         },
         {
           "type": "string",
+          "name": "expressway",
+          "key": "expressway"
+        },
+        {
+          "type": "string",
           "name": "start_date",
           "key": "start_date"
         },

--- a/images/tiler-imposm/config/layers/transport_areas.json
+++ b/images/tiler-imposm/config/layers/transport_areas.json
@@ -43,6 +43,26 @@
         },
         {
           "type": "string",
+          "name": "ref",
+          "key": "ref"
+        },
+        {
+          "type": "string",
+          "name": "iata",
+          "key": "iata"
+        },
+        {
+          "type": "string",
+          "name": "icao",
+          "key": "icao"
+        },
+        {
+          "type": "string",
+          "name": "faa",
+          "key": "faa"
+        },
+        {
+          "type": "string",
           "name": "start_date",
           "key": "start_date"
         },

--- a/images/tiler-imposm/config/layers/transport_lines.json
+++ b/images/tiler-imposm/config/layers/transport_lines.json
@@ -113,6 +113,11 @@
         },
         {
           "type": "string",
+          "name": "expressway",
+          "key": "expressway"
+        },
+        {
+          "type": "string",
           "name": "start_date",
           "key": "start_date"
         },

--- a/images/tiler-imposm/config/layers/transport_multilines.json
+++ b/images/tiler-imposm/config/layers/transport_multilines.json
@@ -127,6 +127,11 @@
           "key": "route"
         },
         {
+          "type": "string",
+          "name": "expressway",
+          "key": "expressway"
+        },
+        {
           "key": "type",
           "name": "relation_type",
           "type": "string"

--- a/images/tiler-imposm/config/layers/transport_points.json
+++ b/images/tiler-imposm/config/layers/transport_points.json
@@ -37,6 +37,21 @@
           "key": "ref"
         },
         {
+          "type": "string",
+          "name": "iata",
+          "key": "iata"
+        },
+        {
+          "type": "string",
+          "name": "icao",
+          "key": "icao"
+        },
+        {
+          "type": "string",
+          "name": "faa",
+          "key": "faa"
+        },
+        {
           "type": "mapping_key",
           "name": "class",
           "key": null

--- a/images/tiler-imposm/queries/ohm_mviews/admin_boundaries_areas.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/admin_boundaries_areas.sql
@@ -11,7 +11,7 @@ ALTER TABLE osm_admin_areas SET (parallel_workers = 4);
 
 DROP MATERIALIZED VIEW IF EXISTS mv_admin_boundaries_areas_z16_20 CASCADE;
 
-SELECT create_areas_mview( 'osm_admin_areas', 'mv_admin_boundaries_areas_z16_20', 1, 0, 'id, osm_id, type', 'admin_level IN (1,2,3,4,5,6,7,8,9,10,11)', NULL);
+SELECT create_areas_mview( 'osm_admin_areas', 'mv_admin_boundaries_areas_z16_20', 1, 0, 'id, osm_id, type', 'admin_level IN (1,2,3,4,5,6,7,8,9,10,11)', NULL, NULL);
 SELECT create_area_mview_from_mview('mv_admin_boundaries_areas_z16_20','mv_admin_boundaries_areas_z13_15', 5, 0.0, NULL);
 SELECT create_area_mview_from_mview('mv_admin_boundaries_areas_z13_15','mv_admin_boundaries_areas_z10_12', 20, 0.0, 'admin_level IN (1,2,3,4,5,6,7,8,9,10)');
 SELECT create_area_mview_from_mview('mv_admin_boundaries_areas_z10_12','mv_admin_boundaries_areas_z8_9', 100, 0.0, 'admin_level IN (1,2,3,4,5,6,7,8,9)');

--- a/images/tiler-imposm/queries/ohm_mviews/amenity.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/amenity.sql
@@ -3,7 +3,10 @@
 -- ============================================================================
 SELECT create_points_mview(
     'osm_amenity_points',
-    'mv_amenity_points'
+    'mv_amenity_points',
+    'id, source, osm_id',
+    NULL,
+    NULL
 );
 
 -- ============================================================================
@@ -17,6 +20,8 @@ SELECT create_areas_mview(
     5,
     5000,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -36,6 +41,8 @@ SELECT create_areas_mview(
     0,
     0,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 SELECT create_points_centroids_mview(

--- a/images/tiler-imposm/queries/ohm_mviews/buildings.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/buildings.sql
@@ -6,7 +6,8 @@ SELECT create_points_mview(
     'osm_buildings_points',
     'mv_buildings_points',
     'id, source, osm_id',
-    ARRAY['NULL as height']
+    ARRAY['NULL as height'],
+    NULL
 );
 
 
@@ -23,6 +24,8 @@ SELECT create_areas_mview(
     5,
     5000,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 
@@ -44,6 +47,8 @@ SELECT create_areas_mview(
     0,
     0,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 SELECT create_points_centroids_mview(

--- a/images/tiler-imposm/queries/ohm_mviews/landuse.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/landuse.sql
@@ -7,7 +7,7 @@
 DROP MATERIALIZED VIEW IF EXISTS mv_landuse_areas_z16_20 CASCADE;
 
 
-SELECT create_areas_mview( 'osm_landuse_areas', 'mv_landuse_areas_z16_20', 0, 0, 'id, osm_id, type', 'NOT (type = ''water'' AND class = ''natural'')');
+SELECT create_areas_mview( 'osm_landuse_areas', 'mv_landuse_areas_z16_20', 0, 0, 'id, osm_id, type', 'NOT (type = ''water'' AND class = ''natural'')', NULL, NULL);
 SELECT create_area_mview_from_mview('mv_landuse_areas_z16_20', 'mv_landuse_areas_z13_15', 5, 10000, NULL);
 SELECT create_area_mview_from_mview('mv_landuse_areas_z13_15', 'mv_landuse_areas_z10_12', 20, 50000, NULL);
 SELECT create_area_mview_from_mview('mv_landuse_areas_z10_12', 'mv_landuse_areas_z8_9', 100, 1000000, NULL);
@@ -19,7 +19,7 @@ SELECT create_area_mview_from_mview('mv_landuse_areas_z8_9', 'mv_landuse_areas_z
 -- Create points materialized view to add laater with centroids
 -- Exclude natrual=water https://github.com/OpenHistoricalMap/issues/issues/1197
 -- ============================================================================
-SELECT create_points_mview('osm_landuse_points','mv_landuse_points' );
+SELECT create_points_mview('osm_landuse_points', 'mv_landuse_points', 'id, source, osm_id', NULL, NULL);
 -- Create points centroids materialized views, add points  only for higher zoom levels
 SELECT create_points_centroids_mview('mv_landuse_areas_z16_20','mv_landuse_points_centroids_z16_20','mv_landuse_points');
 SELECT create_points_centroids_mview( 'mv_landuse_areas_z13_15', 'mv_landuse_points_centroids_z13_15', 'mv_landuse_points');

--- a/images/tiler-imposm/queries/ohm_mviews/non_admin_boundaries_areas.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/non_admin_boundaries_areas.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 DROP MATERIALIZED VIEW IF EXISTS mv_non_admin_boundaries_areas_z16_20 CASCADE;
 
-SELECT create_areas_mview( 'osm_admin_areas', 'mv_non_admin_boundaries_areas_z16_20', 1, 0, 'id, osm_id, type', 'type  <> ''administrative''', 'tags->''religion'' AS religion, tags->''denomination'' AS denomination, tags->''timezone'' AS timezone, tags->''utc'' AS utc, tags->''postal_code'' AS postal_code, tags->''ref'' AS ref, tags->''political_division'' AS political_division' );
+SELECT create_areas_mview( 'osm_admin_areas', 'mv_non_admin_boundaries_areas_z16_20', 1, 0, 'id, osm_id, type', 'type  <> ''administrative''', 'tags->''religion'' AS religion, tags->''denomination'' AS denomination, tags->''timezone'' AS timezone, tags->''utc'' AS utc, tags->''postal_code'' AS postal_code, tags->''ref'' AS ref, tags->''political_division'' AS political_division', NULL);
 SELECT create_area_mview_from_mview('mv_non_admin_boundaries_areas_z16_20','mv_non_admin_boundaries_areas_z13_15', 5, 0.0, NULL);
 SELECT create_area_mview_from_mview('mv_non_admin_boundaries_areas_z13_15','mv_non_admin_boundaries_areas_z10_12', 20, 0.0, NULL );
 SELECT create_area_mview_from_mview('mv_non_admin_boundaries_areas_z10_12','mv_non_admin_boundaries_areas_z8_9', 100, 0.0, NULL );

--- a/images/tiler-imposm/queries/ohm_mviews/others.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/others.sql
@@ -12,6 +12,8 @@ SELECT create_areas_mview(
     100,
     1000000,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -29,6 +31,8 @@ SELECT create_areas_mview(
     20,
     50000,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -44,7 +48,10 @@ SELECT create_points_centroids_mview(
 -- This must be done before creating centroids views that include points
 SELECT create_points_mview(
     'osm_other_points',
-    'mv_other_points'
+    'mv_other_points',
+    'id, source, osm_id',
+    NULL,
+    NULL
 );
 
 
@@ -57,6 +64,8 @@ SELECT create_areas_mview(
     5,
     5000,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -77,6 +86,8 @@ SELECT create_areas_mview(
     0,
     0,
     'id, osm_id, type',
+    NULL,
+    NULL,
     NULL
 );
 SELECT create_points_centroids_mview(

--- a/images/tiler-imposm/queries/ohm_mviews/transport_areas.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/transport_areas.sql
@@ -4,19 +4,32 @@
 -- -- From https://github.com/OpenHistoricalMap/issues/issues/1141 add 'apron', 'terminal' 
 DROP MATERIALIZED VIEW IF EXISTS mv_transport_areas_z16_20 CASCADE;
 
+-- ref is overridden with a coalesce over airport coding schemes so a single
+-- field can be used for labeling (faa > iata > icao > ref). See
+-- https://github.com/OpenHistoricalMap/issues/issues/... (transport_points_centroids ref)
 SELECT create_areas_mview(
     'osm_transport_areas',
     'mv_transport_areas_z16_20',
     0,
     0,
     'id, osm_id, type',
-    'NOT (class = ''highway'' AND type IN (''motorway'', ''motorway_link'', ''trunk'', ''trunk_link'', ''primary'', ''primary_link'', ''secondary'', ''secondary_link'', ''tertiary'', ''tertiary_link'', ''unclassified'', ''residential'', ''service'', ''living_street'', ''cycleway'', ''bridleway''))'
+    'NOT (class = ''highway'' AND type IN (''motorway'', ''motorway_link'', ''trunk'', ''trunk_link'', ''primary'', ''primary_link'', ''secondary'', ''secondary_link'', ''tertiary'', ''tertiary_link'', ''unclassified'', ''residential'', ''service'', ''living_street'', ''cycleway'', ''bridleway''))',
+    NULL,
+    '{"ref": "COALESCE(NULLIF(faa, ''''), NULLIF(iata, ''''), NULLIF(icao, ''''), NULLIF(ref, ''''))"}'::jsonb
 );
 SELECT create_area_mview_from_mview('mv_transport_areas_z16_20','mv_transport_areas_z13_15',5,0.0,NULL);
 SELECT create_area_mview_from_mview('mv_transport_areas_z13_15','mv_transport_areas_z10_12',20,100, 'type IN (''aerodrome'', ''apron'', ''terminal'')');
 
 -- Create points materialized view and centroids views
-SELECT create_points_mview('osm_transport_points', 'mv_transport_points');
+-- ref is overridden with the same coalesce used in mv_transport_areas_* so the
+-- UNION in transport_points_centroids produces a consistent ref across origins
+SELECT create_points_mview(
+    'osm_transport_points',
+    'mv_transport_points',
+    'id, source, osm_id',
+    NULL,
+    '{"ref": "COALESCE(NULLIF(faa, ''''), NULLIF(iata, ''''), NULLIF(icao, ''''), NULLIF(ref, ''''))"}'::jsonb
+);
 SELECT create_points_centroids_mview('mv_transport_areas_z16_20', 'mv_transport_points_centroids_z16_20', 'mv_transport_points');
 SELECT create_points_centroids_mview('mv_transport_areas_z13_15', 'mv_transport_points_centroids_z13_15', 'mv_transport_points');
 SELECT create_points_centroids_mview('mv_transport_areas_z10_12', 'mv_transport_points_centroids_z10_12', NULL);

--- a/images/tiler-imposm/queries/ohm_mviews/transport_lines.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/transport_lines.sql
@@ -300,18 +300,17 @@ END;
 $do$;
 
 
-SELECT create_mview_line_from_mview('mv_transport_lines_z16_20', 'mv_transport_lines_z13_15', 5, 'type IN (''motorway'', ''motorway_link'', ''trunk'', ''trunk_link'', ''construction'', ''primary'', ''primary_link'', ''rail'', ''secondary'', ''secondary_link'', ''tertiary'', ''tertiary_link'', ''miniature'', ''narrow_gauge'', ''dismantled'', ''abandoned'', ''disused'', ''razed'', ''light_rail'', ''preserved'', ''proposed'', ''tram'', ''funicular'', ''monorail'', ''taxiway'', ''runway'', ''raceway'', ''residential'', ''service'', ''unclassified'', ''ferry'') OR class IN (''railway'')');
+SELECT create_mview_line_from_mview('mv_transport_lines_z16_20', 'mv_transport_lines_z13_15', 5, 'type IN (''motorway'', ''motorway_link'', ''trunk'', ''trunk_link'', ''construction'', ''primary'', ''primary_link'', ''rail'', ''secondary'', ''secondary_link'', ''tertiary'', ''tertiary_link'', ''miniature'', ''narrow_gauge'', ''dismantled'', ''abandoned'', ''disused'', ''razed'', ''light_rail'', ''preserved'', ''proposed'', ''tram'', ''funicular'', ''monorail'', ''taxiway'', ''runway'', ''raceway'', ''residential'', ''service'', ''unclassified'', ''ferry'', ''track'', ''path'', ''footway'', ''cycleway'', ''pedestrian'', ''living_street'', ''steps'', ''bridleway'') OR class IN (''railway'')');
 SELECT create_mview_line_from_mview('mv_transport_lines_z13_15', 'mv_transport_lines_z10_12', 20, 'type IN (''motorway'', ''motorway_link'', ''trunk'', ''trunk_link'', ''construction'', ''primary'', ''primary_link'', ''rail'', ''secondary'', ''secondary_link'', ''tertiary'', ''tertiary_link'', ''miniature'', ''narrow_gauge'', ''dismantled'', ''abandoned'', ''disused'', ''razed'', ''light_rail'', ''preserved'', ''proposed'', ''tram'', ''funicular'', ''monorail'', ''taxiway'', ''runway'', ''ferry'') OR class IN (''railway'')');
 SELECT create_mview_line_from_mview('mv_transport_lines_z10_12', 'mv_transport_lines_z8_9', 100, NULL);
 SELECT create_mview_line_from_mview('mv_transport_lines_z8_9', 'mv_transport_lines_z6_7', 200 , 'type IN (''motorway'', ''motorway_link'', ''trunk'', ''trunk_link'', ''construction'', ''primary'', ''primary_link'', ''rail'', ''secondary'', ''secondary_link'', ''ferry'') OR class IN (''railway'')');
 SELECT create_mview_line_from_mview('mv_transport_lines_z6_7', 'mv_transport_lines_z5', 1000 , NULL);
 
 
-
 -- Refresh lines views
--- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z5;
--- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z6_7;
--- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z8_9;
--- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z10_12;
--- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z13_15;
 -- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z16_20;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z13_15;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z10_12;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z8_9;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z6_7;
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY mv_transport_lines_z5;

--- a/images/tiler-imposm/queries/ohm_mviews/transport_lines.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/transport_lines.sql
@@ -59,6 +59,7 @@ BEGIN
           OR (NULLIF(sm.railway, '')   IS NOT NULL AND sm.railway      IS DISTINCT FROM tl.railway)
           OR (NULLIF(sm.aeroway, '')   IS NOT NULL AND sm.aeroway      IS DISTINCT FROM tl.aeroway)
           OR (NULLIF(sm.route, '')     IS NOT NULL AND sm.route        IS DISTINCT FROM tl.route)
+          OR (NULLIF(sm.expressway,'') IS NOT NULL AND sm.expressway   IS DISTINCT FROM tl.expressway)
           OR (sm.tunnel  IS NOT NULL AND sm.tunnel  IS DISTINCT FROM tl.tunnel)
           OR (sm.bridge  IS NOT NULL AND sm.bridge  IS DISTINCT FROM tl.bridge)
           OR (sm.oneway  IS NOT NULL AND sm.oneway  IS DISTINCT FROM tl.oneway)
@@ -151,6 +152,7 @@ BEGIN
         tl.railway,
         tl.aeroway,
         tl.route,
+        tl.expressway,
         tl.tags,
         tl.start_date,
         LEAST(NULLIF(tl.end_date, ''), srd.earliest_rel_start) AS end_date,
@@ -184,6 +186,7 @@ BEGIN
         COALESCE(NULLIF(sm.railway, ''),   tl.railway)               AS railway,
         COALESCE(NULLIF(sm.aeroway, ''),   tl.aeroway)               AS aeroway,
         COALESCE(NULLIF(sm.route,   ''),   tl.route)                 AS route,
+        COALESCE(NULLIF(sm.expressway,''), tl.expressway)            AS expressway,
         sm.tags || tl.tags AS tags,
         sm.start_date,
         sm.end_date,
@@ -229,6 +232,7 @@ BEGIN
         NULLIF(aeroway, '') AS aeroway,
         NULLIF(highway, '') AS highway,
         NULLIF(route, '') AS route,
+        NULLIF(expressway, '') AS expressway,
         NULLIF(start_date, '') AS start_date,
         NULLIF(end_date, '') AS end_date,
         isodatetodecimaldate(pad_date(start_date, 'start'), FALSE) AS start_decdate,
@@ -275,6 +279,7 @@ BEGIN
         NULLIF(aeroway, '') AS aeroway,
         NULLIF(highway, '') AS highway,
         NULLIF(route, '') AS route,
+        NULLIF(expressway, '') AS expressway,
         NULLIF(start_date, '') AS start_date,
         NULLIF(end_date, '') AS end_date,
         isodatetodecimaldate(pad_date(start_date, 'start'), FALSE) AS start_decdate,

--- a/images/tiler-imposm/queries/ohm_mviews/water.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/water.sql
@@ -6,7 +6,7 @@
 -- Delete existing views, in cascade
 DROP MATERIALIZED VIEW IF EXISTS mv_water_areas_z16_20 CASCADE;
 
-SELECT create_areas_mview('osm_water_areas','mv_water_areas_z16_20',0,0,'id, osm_id, type');
+SELECT create_areas_mview('osm_water_areas', 'mv_water_areas_z16_20', 0, 0, 'id, osm_id, type', NULL, NULL, NULL);
 SELECT create_area_mview_from_mview('mv_water_areas_z16_20','mv_water_areas_z13_15',5,0.0,NULL);
 SELECT create_area_mview_from_mview('mv_water_areas_z13_15','mv_water_areas_z10_12',20,100, 'type IN (''water'',''pond'',''basin'',''canal'',''mill_pond'',''riverbank'')');
 SELECT create_area_mview_from_mview('mv_water_areas_z10_12','mv_water_areas_z8_9',100,10000, NULL);

--- a/images/tiler-imposm/queries/utils/create_01_areas_mview.sql
+++ b/images/tiler-imposm/queries/utils/create_01_areas_mview.sql
@@ -18,15 +18,18 @@
 --   unique_columns  TEXT              - Comma-separated columns for unique index (default: 'id, osm_id, type')
 --   where_filter    TEXT              - Optional WHERE clause filter (e.g., "type != 'barrier'" or "class NOT IN ('power', 'military')"). NULL = no filter
 --   tag_columns     TEXT              - Optional extra columns from tags (e.g., "tags->'religion' AS religion, tags->'denomination' AS denomination"). NULL = none
+--   column_overrides JSONB            - Optional mapping {column_name: sql_expression} to override how an existing column is selected (e.g., '{"ref": "COALESCE(faa, iata, icao, NULLIF(ref, ''''))"}'). NULL = no overrides
 --
 -- Notes:
 --   - Creates the materialized view using a temporary swap mechanism
 --   - Adds a spatial index (GiST) on geometry and a unique index on unique_columns
 --   - Useful for creating views at different zoom levels with variable simplification
 --   - where_filter is appended to WHERE clause with AND, so use conditions like "type != 'barrier'" not "AND type != 'barrier'"
+--   - column_overrides replaces the default expression for a column (including the NULLIF text-wrapping), and the alias is kept as the column name
 -- ============================================================================
 DROP FUNCTION IF EXISTS create_areas_mview(TEXT, TEXT, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT);
 DROP FUNCTION IF EXISTS create_areas_mview(TEXT, TEXT, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS create_areas_mview(TEXT, TEXT, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, TEXT, JSONB);
 
 CREATE OR REPLACE FUNCTION create_areas_mview(
     source_table TEXT,
@@ -35,7 +38,8 @@ CREATE OR REPLACE FUNCTION create_areas_mview(
     min_area DOUBLE PRECISION DEFAULT 0,
     unique_columns TEXT DEFAULT 'id, osm_id, type',
     where_filter TEXT DEFAULT NULL,
-    tag_columns TEXT DEFAULT NULL
+    tag_columns TEXT DEFAULT NULL,
+    column_overrides JSONB DEFAULT NULL
 )
 RETURNS void AS $$
 DECLARE 
@@ -74,8 +78,11 @@ BEGIN
     
     -- Build SQL - get all columns from source table and replace geometry, handle special columns
     -- Exclude start_decdate and end_decdate because they will be recalculated
+    -- column_overrides (if provided) takes precedence and fully replaces the default expression for a column
     SELECT COALESCE(string_agg(
-        CASE 
+        CASE
+            WHEN column_overrides IS NOT NULL AND column_overrides ? column_name THEN
+                format('%s AS %I', column_overrides->>column_name, column_name)
             WHEN column_name = 'geometry' THEN format('%s AS geometry', simplify_expr)
             WHEN column_name = 'area' THEN format(
                 '%I, ROUND(CAST(%I AS numeric), 1)::numeric(20,1) AS area_m2, ROUND(CAST(%I AS numeric) / 1000000, 1)::numeric(20,1) AS area_km2',

--- a/images/tiler-imposm/queries/utils/create_02_points_mview.sql
+++ b/images/tiler-imposm/queries/utils/create_02_points_mview.sql
@@ -20,6 +20,7 @@
 --                                - Example: 'CASE WHEN tags->''height'' IS NULL OR trim(tags->''height'') = '''' THEN NULL WHEN trim(regexp_replace(tags->''height'', ''[^0-9\.]'', '''', ''g'')) = '''' THEN NULL ELSE regexp_replace(tags->''height'', ''[^0-9\.]'', '''', ''g'')::double precision END AS height'
 --                                - Use double single quotes ('') inside expressions for string literals
 --                                - Expressions are used as-is, no automatic generation
+--   column_overrides   JSONB   - Optional mapping {column_name: sql_expression} to override how an existing column is selected (e.g., '{"ref": "COALESCE(faa, iata, icao, NULLIF(ref, ''''))"}'). NULL = no overrides
 --
 -- Returns:
 --   TEXT    - Name of the created materialized view
@@ -31,14 +32,17 @@
 --   - Follows the same structure as create_simplified_mview
 --   - extra_columns: All expressions are used exactly as provided, must include 'AS column_name'
 --   - Columns specified in extra_columns will be excluded from the source table to avoid duplicates
+--   - column_overrides replaces the default expression for a column (including the NULLIF text-wrapping), and the alias is kept as the column name
 -- ============================================================================
 DROP FUNCTION IF EXISTS create_points_mview(TEXT, TEXT, TEXT, TEXT[]);
+DROP FUNCTION IF EXISTS create_points_mview(TEXT, TEXT, TEXT, TEXT[], JSONB);
 
 CREATE OR REPLACE FUNCTION create_points_mview(
     points_table TEXT,
     mview_name TEXT,
     unique_columns TEXT DEFAULT 'id, source, osm_id',
-    extra_columns TEXT[] DEFAULT NULL
+    extra_columns TEXT[] DEFAULT NULL,
+    column_overrides JSONB DEFAULT NULL
 )
 RETURNS TEXT AS $$
 DECLARE
@@ -79,8 +83,11 @@ BEGIN
     
     -- Build SQL - get all columns from points_table and add calculated ones
     -- Exclude start_decdate, end_decdate, area columns, and any columns from extra_columns
+    -- column_overrides (if provided) takes precedence and fully replaces the default expression for a column
     SELECT COALESCE(string_agg(
-        CASE 
+        CASE
+            WHEN column_overrides IS NOT NULL AND column_overrides ? column_name THEN
+                format('%s AS %I', column_overrides->>column_name, column_name)
             WHEN column_name = 'name' THEN 'NULLIF(name, '''') AS name'
             WHEN column_name = 'start_date' THEN 'NULLIF(start_date, '''') AS start_date'
             WHEN column_name = 'end_date' THEN 'NULLIF(end_date, '''') AS end_date'

--- a/images/tiler-monitor/pipeline-monitor/checks/imposm_import.py
+++ b/images/tiler-monitor/pipeline-monitor/checks/imposm_import.py
@@ -218,6 +218,8 @@ def _get_changeset_elements(changeset_id):
                 timestamp = elem.attrib.get("timestamp", "")
                 # Count nodes for ways (to detect invalid geometries)
                 node_count = len(elem.findall("nd")) if elem_type == "way" else 0
+                # Count members for relations (to detect empty relations)
+                member_count = len(elem.findall("member")) if elem_type == "relation" else 0
                 elements.append({
                     "type": elem_type,
                     "osm_id": int(osm_id),
@@ -226,6 +228,7 @@ def _get_changeset_elements(changeset_id):
                     "tags": tags,
                     "timestamp": timestamp,
                     "node_count": node_count,
+                    "member_count": member_count,
                 })
     return elements
 

--- a/images/tiler-monitor/pipeline-monitor/imposm_config_loader.py
+++ b/images/tiler-monitor/pipeline-monitor/imposm_config_loader.py
@@ -254,6 +254,16 @@ def get_skip_reason(elem, tag_to_check, table_details, importable_relation_types
     if not tags:
         return {"reason": "Element has no tags", "commentable": False}
 
+    # Skip relations with no members — imposm cannot build geometry from an
+    # empty relation, so it will never appear in the tiler DB.
+    if elem_type == "relation":
+        member_count = elem.get("member_count", -1)
+        if member_count == 0:
+            return {
+                "reason": "Relation has no members — imposm cannot import empty relations",
+                "commentable": False,
+            }
+
     # Check non-importable relation types early.
     # Relations with types like "waterway" are grouping relations whose member
     # ways get imported individually — the relation itself is never stored.

--- a/images/tiler-server-martin/config/nginx.conf.template
+++ b/images/tiler-server-martin/config/nginx.conf.template
@@ -15,7 +15,7 @@ http {
 
     # === Tile cache (dynamic: ohm, ohm_admin, etc.) ===
     # Tiles expire automatically via proxy_cache_valid TTLs (per zoom range).
-    # Manual purge: append ?purge=1 to any tile URL to bypass cache and fetch fresh.
+    # Manual bypass: append ?fresh_tiles=1 to any tile URL to bypass cache and fetch fresh.
     proxy_cache_path /var/cache/nginx/tiles
         levels=1:2
         keys_zone=tiles:200m
@@ -46,17 +46,17 @@ http {
     # nginx proxy_cache TTL varies by zoom range (generated per location block).
     # Ranges match materialized view zoom ranges. Lower zooms cache longer
     # (less change), higher zooms expire faster (more edits).
-    # Manual purge via ?purge=1; TTLs are the automatic safety net.
+    # Manual bypass via ?fresh_tiles=1; TTLs are the automatic safety net.
     #   z0-2:   24h    z3-5:  24h    z6-7:  16h    z8-9:  12h
     #   z10-12:  8h    z13-15: 4h    z16-20: 1h
     # Browser Cache-Control is set to "no-store" for dynamic tiles so
     # browsers always revalidate with nginx.
 
-    # === Cache bypass for force-purge ===
-    # Append ?purge=1 to any tile URL to skip the cache and fetch fresh from Martin.
+    # === Cache bypass for fresh tiles ===
+    # Append ?fresh_tiles=1 to any tile URL to skip the cache and fetch fresh from Martin.
     # The fresh response replaces the old cache entry (cache_key = $uri, without query params).
-    # Usage: /maps/ohm/10/512/340.pbf?purge=1
-    map $arg_purge $cache_bypass {
+    # Usage: /maps/ohm/10/512/340.pbf?fresh_tiles=1
+    map $arg_fresh_tiles $cache_bypass {
         default 0;
         "1"     1;
     }

--- a/images/tiler-server-martin/start.sh
+++ b/images/tiler-server-martin/start.sh
@@ -25,7 +25,7 @@ cat > /app/config/config.yaml <<EOF
 listen_addresses: '0.0.0.0:${MARTIN_INTERNAL_PORT}'
 worker_processes: ${MARTIN_WORKER_PROCESSES:-8}
 # Disable Martin's internal tile cache so tiles are always generated fresh.
-# Nginx handles caching with TTLs + ?purge=1 bypass.
+# Nginx handles caching with TTLs + ?fresh_tiles=1 bypass.
 cache_size_mb: 0
 
 postgres:

--- a/images/tiler-server-martin/static/index.html
+++ b/images/tiler-server-martin/static/index.html
@@ -68,9 +68,9 @@
     #map-controls button { background: rgba(22,33,62,0.9); border: 1px solid rgba(255,255,255,0.15); color: #eee; padding: 6px 12px; border-radius: 6px; font-size: 12px; cursor: pointer; }
     #map-controls button:hover { background: rgba(22,33,62,1); }
     #map-controls button.active { background: #0f3460; border-color: #4fc3f7; color: #4fc3f7; }
-    #map-controls button.purge { border-color: #e57373; color: #e57373; }
-    #map-controls button.purge:hover { background: rgba(229,115,115,0.15); }
-    #map-controls button.purge.active { background: #e57373; color: #fff; border-color: #e57373; }
+    #map-controls button.fresh-tiles { border-color: #e57373; color: #e57373; }
+    #map-controls button.fresh-tiles:hover { background: rgba(229,115,115,0.15); }
+    #map-controls button.fresh-tiles.active { background: #e57373; color: #fff; border-color: #e57373; }
     #zoom-level { background: rgba(22,33,62,0.9); padding: 8px 14px; border-radius: 6px; font-size: 13px; pointer-events: auto; }
 
     /* Tile info */
@@ -135,7 +135,7 @@
     <div id="map-header">
       <div id="map-controls">
         <button id="btn-grid" onclick="toggleGrid()">Grid</button>
-        <button id="btn-purge" class="purge" onclick="togglePurge()" title="Toggle cache bypass: tiles load fresh from Martin">Purge Cache</button>
+        <button id="btn-fresh-tiles" class="fresh-tiles" onclick="toggleFreshTiles()" title="Toggle cache bypass: tiles load fresh from Martin">Req Fresh Tiles</button>
       </div>
       <div id="zoom-level">z0</div>
     </div>
@@ -198,20 +198,20 @@
     }
     document.getElementById('btn-grid').classList.add('active');
 
-    // Purge mode: toggle ?purge=1 on all tile requests to bypass nginx cache
+    // Fresh tiles mode: toggle ?fresh_tiles=1 on all tile requests to bypass nginx cache
     // cacheBuster is appended to tile URLs to defeat MapLibre's in-memory cache.
-    // It is incremented each time purge is toggled off, so MapLibre sees new URLs
+    // It is incremented each time fresh tiles is toggled off, so MapLibre sees new URLs
     // and re-fetches from nginx (which already has the fresh tiles from BYPASS).
-    let purgeMode = false;
+    let freshTilesMode = false;
     let cacheBuster = 0;
 
-    function togglePurge() {
-      purgeMode = !purgeMode;
-      const btn = document.getElementById('btn-purge');
-      btn.classList.toggle('active', purgeMode);
-      btn.textContent = purgeMode ? 'Purge ON' : 'Purge Cache';
+    function toggleFreshTiles() {
+      freshTilesMode = !freshTilesMode;
+      const btn = document.getElementById('btn-fresh-tiles');
+      btn.classList.toggle('active', freshTilesMode);
+      btn.textContent = freshTilesMode ? 'Fresh Tiles ON' : 'Fresh Tiles';
 
-      if (!purgeMode) {
+      if (!freshTilesMode) {
         // Increment cache buster so MapLibre treats all tile URLs as new
         cacheBuster++;
       }
@@ -224,10 +224,10 @@
         if (!source || !source.tiles) return;
         const urls = source.tiles.map(url => {
           const base = url.split('?')[0];
-          if (purgeMode) {
-            return base + '?purge=1&_v=' + cacheBuster;
+          if (freshTilesMode) {
+            return base + '?fresh_tiles=1&_v=' + cacheBuster;
           }
-          // cacheBuster > 0 means we've done at least one purge cycle
+          // cacheBuster > 0 means we've done at least one fresh tiles cycle
           return cacheBuster > 0 ? base + '?_v=' + cacheBuster : base;
         });
         source.setTiles(urls);
@@ -429,7 +429,7 @@
     async function addCompositeSource(group) {
       const compositeFns = group.functions.join(',');
       const sourceId = `src-composite-${group.name}`;
-      // Use /maps/{group}/ route which goes through nginx cache + purge support,
+      // Use /maps/{group}/ route which goes through nginx cache + fresh_tiles support,
       // instead of Martin's native TileJSON URLs which bypass cache.
       const cachedTileUrl = `${MARTIN_BASE}/maps/${group.name}/{z}/{x}/{y}.pbf`;
       const tileJsonUrl = `${MARTIN_BASE}/${compositeFns}`;
@@ -470,7 +470,7 @@
         });
 
         activeSources['__composite__'] = { sourceId, layerIds, color: '#4fc3f7' };
-        if (purgeMode || cacheBuster > 0) applyTileUrls();
+        if (freshTilesMode || cacheBuster > 0) applyTileUrls();
       } catch (e) {
         console.error('Failed to add composite source:', e);
       }
@@ -608,7 +608,7 @@
       }
 
       activeSources[name] = { sourceId, layerIds, color };
-      if (purgeMode || cacheBuster > 0) applyTileUrls();
+      if (freshTilesMode || cacheBuster > 0) applyTileUrls();
       const el = document.getElementById(`src-item-${name}`);
       if (el) el.classList.add('active');
     }

--- a/images/tiler-server-martin/static/index.html
+++ b/images/tiler-server-martin/static/index.html
@@ -33,7 +33,9 @@
     .layer-zoom { font-size: 11px; color: #666; white-space: nowrap; flex-shrink: 0; }
 
     /* Composite layer info */
-    .composite-layer-info { padding: 3px 10px 3px 22px; font-size: 12px; color: #888; display: flex; align-items: center; gap: 8px; }
+    .composite-layer-info { padding: 3px 10px 3px 14px; font-size: 12px; color: #888; display: flex; align-items: center; gap: 8px; }
+    .composite-layer-info.hidden-layer { opacity: 0.45; }
+    .composite-layer-info input[type="checkbox"] { accent-color: #4fc3f7; cursor: pointer; margin: 0; }
     .composite-dot { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
 
     /* Source item (for groups) */
@@ -391,7 +393,14 @@
           const zl = zoomLabel(name);
           const info = document.createElement('div');
           info.className = 'composite-layer-info';
-          info.innerHTML = `<div class="composite-dot" style="background:${color}"></div><span style="flex:1">${name}</span>${zl ? `<span style="color:#666;font-size:11px">${zl}</span>` : ''}`;
+          info.id = `comp-item-${name}`;
+          info.innerHTML = `<input type="checkbox" checked><div class="composite-dot" style="background:${color}"></div><span style="flex:1">${name}</span>${zl ? `<span style="color:#666;font-size:11px">${zl}</span>` : ''}`;
+          const cb = info.querySelector('input');
+          cb.onchange = (ev) => {
+            ev.stopPropagation();
+            toggleCompositeLayer(name, cb.checked);
+            info.classList.toggle('hidden-layer', !cb.checked);
+          };
           content.appendChild(info);
         });
 
@@ -446,9 +455,12 @@
         });
 
         const layerIds = [];
+        const layerByFn = {};
         const layers = group.functions;
-        
-        layers.forEach((fnName, i) => {
+
+        // Build specs first so we can sort: fills/lines first, circles (centroids/points) last
+        // so points always render on top while preserving the relative order within each type.
+        const specs = layers.map((fnName, i) => {
           const color = sourceColors[fnName] || COLORS[i % COLORS.length];
           const sourceLayer = sourceLayerNames[fnName] || fnName;
           const slName = fnName.toLowerCase();
@@ -463,13 +475,22 @@
             type = 'fill';
             paint = { 'fill-color': color, 'fill-opacity': 0.35, 'fill-outline-color': color };
           }
-
-          const layerId = `lyr-composite-${fnName}-${i}`;
-          map.addLayer({ id: layerId, type, source: sourceId, 'source-layer': sourceLayer, paint });
-          layerIds.push(layerId);
+          return { fnName, sourceLayer, type, paint, i };
         });
 
-        activeSources['__composite__'] = { sourceId, layerIds, color: '#4fc3f7' };
+        const ordered = [
+          ...specs.filter(s => s.type !== 'circle'),
+          ...specs.filter(s => s.type === 'circle'),
+        ];
+
+        ordered.forEach(spec => {
+          const layerId = `lyr-composite-${spec.fnName}-${spec.i}`;
+          map.addLayer({ id: layerId, type: spec.type, source: sourceId, 'source-layer': spec.sourceLayer, paint: spec.paint });
+          layerIds.push(layerId);
+          layerByFn[spec.fnName] = layerId;
+        });
+
+        activeSources['__composite__'] = { sourceId, layerIds, layerByFn, color: '#4fc3f7' };
         if (freshTilesMode || cacheBuster > 0) applyTileUrls();
       } catch (e) {
         console.error('Failed to add composite source:', e);
@@ -479,6 +500,14 @@
     function toggleSource(name) {
       if (activeSources[name]) removeSource(name);
       else addSource(name);
+    }
+
+    function toggleCompositeLayer(fnName, visible) {
+      const composite = activeSources['__composite__'];
+      if (!composite) return;
+      const layerId = composite.layerByFn && composite.layerByFn[fnName];
+      if (!layerId || !map.getLayer(layerId)) return;
+      map.setLayoutProperty(layerId, 'visibility', visible ? 'visible' : 'none');
     }
 
     function removeSource(name) {

--- a/images/tiler-server-martin/static/index.html
+++ b/images/tiler-server-martin/static/index.html
@@ -617,11 +617,23 @@
       document.getElementById('right-panel').classList.add('hidden');
     }
 
+    const CLICK_BUFFER = 5;
     map.on('click', (e) => {
       if (!inspectEnabled) return;
 
-      const features = map.queryRenderedFeatures(e.point)
-        .filter(f => f.layer.id.startsWith('lyr-'));
+      const bbox = [
+        [e.point.x - CLICK_BUFFER, e.point.y - CLICK_BUFFER],
+        [e.point.x + CLICK_BUFFER, e.point.y + CLICK_BUFFER]
+      ];
+      const seen = new Set();
+      const features = map.queryRenderedFeatures(bbox)
+        .filter(f => {
+          if (!f.layer.id.startsWith('lyr-')) return false;
+          const key = `${f.layer.id}:${f.sourceLayer}:${f.id ?? ''}:${f.properties.osm_id ?? ''}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
       const panel = document.getElementById('right-panel');
 
       if (!features.length) {

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=7ad2415aef444aa98775b1a5a8e4cd5124b7b8a5
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=67afba8984cc55a864f99199249afae99a721c39
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \
@@ -67,7 +67,7 @@ RUN SECRET_KEY_BASE_DUMMY=1  \
     bundle exec rails assets:precompile
 
 # Leaflet timeslider assets
-ENV LEAFLET_OHM_TIMESLIDER_V2=dd0acbdc9432fae6a4d09a17a4848c391e5064f0
+ENV LEAFLET_OHM_TIMESLIDER_V2=d41b5113691bb6e96ba686c8a66921a766dc57e0
 RUN git clone https://github.com/OpenHistoricalMap/leaflet-ohm-timeslider-v2.git public/leaflet-ohm-timeslider-v2 && \
     cd public/leaflet-ohm-timeslider-v2 && \
     git checkout $LEAFLET_OHM_TIMESLIDER_V2 && \

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=67afba8984cc55a864f99199249afae99a721c39
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=44e8c4e9ef6f5c3362f6c091dd428e8d95c0398f
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \


### PR DESCRIPTION
* Rename the parameter to `fresh_tiles=1` to request fresh tiles.
* Skip detections of relations without a member for the monitor.
* Include `track`, `path`, `footway`, `cycleway`, and `pedestrian` tags starting at `zoom=13` ([[#1315](https://github.com/OpenHistoricalMap/issues/issues/1315)](https://github.com/OpenHistoricalMap/issues/issues/1315)).
* Add an `expressway` column for `transport_lines` ([[#1321](https://github.com/OpenHistoricalMap/issues/issues/1321)](https://github.com/OpenHistoricalMap/issues/issues/1321)).
* Expose airport codes ([[#1314](https://github.com/OpenHistoricalMap/issues/issues/1314)](https://github.com/OpenHistoricalMap/issues/issues/1314)).
* Update the tagging configuration to restart the web Docker container and fetch the latest DB files.
* Set `OSMX_INITIAL_SEQNUM` for `osmcha_ohmx_adiff` to prevent server DB crashes.

