### PR TITLE
Update web and db images for upstream compatibility

### DIFF
--- a/compose/web.yml
+++ b/compose/web.yml
@@ -22,7 +22,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./../images/web/start.sh:/var/www/start.sh
-      - ./../../ohm-website-patches:/opt/ohm-patches:ro
     env_file:
       - ./../envs/.env.web
     ports:

--- a/compose/web.yml
+++ b/compose/web.yml
@@ -1,5 +1,6 @@
 services:
   db:
+    container_name: db
     platform: linux/amd64
     image: ohm-db:v2
     build:
@@ -14,18 +15,18 @@ services:
       - web_network
 
   web:
+    container_name: web
     image: ohm-web:v1
     build:
       context: ./../images/web
       dockerfile: Dockerfile
     volumes:
-      - ./../../ohm-website/:/var/www/
-      - ./../images/web/config/settings.yml:/tmp/settings.yml:rw
       - ./../images/web/start.sh:/var/www/start.sh
+      - ./../../ohm-website-patches:/opt/ohm-patches:ro
     env_file:
       - ./../envs/.env.web
     ports:
-      - '3000:3000'
+      - '3000:80'
     networks:
       - web_network
     depends_on:
@@ -33,11 +34,30 @@ services:
       - memcached
 
   memcached:
+    container_name: memcached
     image: memcached:latest
     ports:
       - '11211:11211'
     networks:
       - web_network
+
+  # cgimap:
+  #   container_name: cgimap
+  #   image: ohm-cgimap:v1
+  #   build:
+  #     context: ./../images/cgimap
+  #     dockerfile: Dockerfile
+  #   env_file:
+  #     - ./../envs/.env.web
+  #   environment:
+  #     MEMCACHE_SERVER: memcached:11211
+  #   # ports:
+  #   #   - '8000:8000'
+  #   networks:
+  #     - web_network
+  #   depends_on:
+  #     - db
+  #     - memcached
 
 networks:
   web_network:

--- a/images/db/Dockerfile
+++ b/images/db/Dockerfile
@@ -1,7 +1,6 @@
-# Stage 1: Compilar el plugin para PostgreSQL 17 con PostGIS
-FROM postgis/postgis:17-3.5 AS builder
+FROM postgres:17 AS builder
 
-# Instalar dependencias de compilación
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
@@ -18,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Clonar y compilar el plugin osmdbt para PostgreSQL 17
+# Clone and build osmdbt plugin for PostgreSQL 17
 RUN git clone https://github.com/openstreetmap/osmdbt.git /tmp/osmdbt && \
     cd /tmp/osmdbt && \
     git checkout v0.9 && \
@@ -27,7 +26,12 @@ RUN git clone https://github.com/openstreetmap/osmdbt.git /tmp/osmdbt && \
     cmake .. && \
     make
 
-FROM postgis/postgis:17-3.5
+FROM postgres:17
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-17-postgis-3 \
+    postgresql-17-postgis-3-scripts \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /tmp/osmdbt/postgresql-plugin/build/osm-logical.so /usr/lib/postgresql/17/lib/osm-logical.so
 

--- a/images/db/Dockerfile
+++ b/images/db/Dockerfile
@@ -33,6 +33,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-17-postgis-3-scripts \
     && rm -rf /var/lib/apt/lists/*
 
+# Auto-create required extensions on fresh initdb
+COPY ./scripts/init-extensions.sh /docker-entrypoint-initdb.d/10-extensions.sh
+RUN chmod +x /docker-entrypoint-initdb.d/10-extensions.sh
+
 COPY --from=builder /tmp/osmdbt/postgresql-plugin/build/osm-logical.so /usr/lib/postgresql/17/lib/osm-logical.so
 
 RUN ln -s /usr/lib/postgresql/17/lib/osm-logical.so /usr/lib/postgresql/17/lib/osm_logical.so

--- a/images/db/Dockerfile
+++ b/images/db/Dockerfile
@@ -1,5 +1,5 @@
-# Stage 1: Compilar el plugin para PostgreSQL 17
-FROM postgres:17 AS builder
+# Stage 1: Compilar el plugin para PostgreSQL 17 con PostGIS
+FROM postgis/postgis:17-3.5 AS builder
 
 # Instalar dependencias de compilación
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -27,7 +27,7 @@ RUN git clone https://github.com/openstreetmap/osmdbt.git /tmp/osmdbt && \
     cmake .. && \
     make
 
-FROM postgres:17
+FROM postgis/postgis:17-3.5
 
 COPY --from=builder /tmp/osmdbt/postgresql-plugin/build/osm-logical.so /usr/lib/postgresql/17/lib/osm-logical.so
 

--- a/images/db/scripts/init-extensions.sh
+++ b/images/db/scripts/init-extensions.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+psql --username="$POSTGRES_USER" --dbname="$POSTGRES_DB" -v ON_ERROR_STOP=1 <<-'EOSQL'
+    CREATE EXTENSION IF NOT EXISTS postgis;
+    CREATE EXTENSION IF NOT EXISTS hstore;
+    CREATE EXTENSION IF NOT EXISTS btree_gist;
+EOSQL

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -31,7 +31,7 @@ RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && 
     mv /tmp/ohm-website-$OPENHISTORICALMAP_WEBSITE_GITSHA/* $workdir && \
     rm -rf /tmp/*
 
-RUN gem install bundler -v 2.6.9 --no-document && \
+RUN gem install bundler -v 4.0.11 --no-document && \
     bundle install && \
     yarn install && \
     bundle exec rake yarn:install
@@ -116,6 +116,7 @@ RUN BUILD_DEPS=" \
     gifsicle \
     postgresql-client \
     curl \
+    git \
     libvips \
     nodejs \
     \
@@ -123,7 +124,7 @@ RUN BUILD_DEPS=" \
     \
     # Install Passenger as a gem and compile the Apache module
     \
-    && gem install passenger --no-document \
+    && gem install passenger -v 6.1.3 --no-document \
     && yes | passenger-install-apache2-module --auto --languages ruby \
     && passenger-config validate-install --auto \
     \
@@ -152,8 +153,8 @@ RUN a2enmod headers setenvif proxy proxy_http proxy_fcgi fcgid rewrite lbmethod_
     echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
     apache2ctl configtest
 
-# Install bundler 2.6.9 — supports default gem replacement, avoids Passenger preloader Gem::LoadError.
-RUN gem install bundler -v 2.6.9 --no-document
+# Install bundler matching ohm-website Gemfile.lock to avoid Passenger preloader Gem::LoadError.
+RUN gem install bundler -v 4.0.11 --no-document
 
 
 RUN echo '#!/bin/bash\nexec /usr/local/bin/ruby --yjit --yjit-exec-mem-size=64 "$@"' > /usr/local/bin/ruby_yjit && \

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-slim AS builder
+FROM ruby:3.4-slim AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     workdir=/var/www \
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=8690db86e4e5b51c4d59c1e2ec273bb2f8471189
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=6dc7d515a60b70a27f90e0e8d333df645e37e9a8
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \
@@ -77,7 +77,7 @@ RUN git clone https://github.com/OpenHistoricalMap/leaflet-ohm-timeslider-v2.git
     cp leaflet-ohm-timeslider.* $workdir/app/assets/stylesheets/ && \
     cp assets/* $workdir/app/assets/images/
 
-FROM ruby:3.3-slim
+FROM ruby:3.4-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \
     workdir=/var/www \

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR $workdir
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git curl gnupg build-essential \
-    libarchive-dev zlib1g-dev libcurl4-openssl-dev \
+    libarchive-dev zlib1g-dev libcurl4-openssl-dev libgd-dev \
     apache2 apache2-dev libapache2-mod-fcgid libapr1-dev libaprutil1-dev \
     postgresql-client libpq-dev libxml2-dev libyaml-dev \
     pngcrush optipng advancecomp pngquant jhead jpegoptim gifsicle libjpeg-progs unzip\

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=6b4b282580a8e58f5d61a63f68a87e970e28608c
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=ecd8301fd333946b50137fb702bb5c1cbd1c3970
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -31,7 +31,7 @@ RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && 
     mv /tmp/ohm-website-$OPENHISTORICALMAP_WEBSITE_GITSHA/* $workdir && \
     rm -rf /tmp/*
 
-RUN gem install bundler && \
+RUN gem install bundler -v 2.6.9 --no-document && \
     bundle install && \
     yarn install && \
     bundle exec rake yarn:install
@@ -151,6 +151,10 @@ RUN a2enmod headers setenvif proxy proxy_http proxy_fcgi fcgid rewrite lbmethod_
     a2ensite production && \
     echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
     apache2ctl configtest
+
+# Install bundler 2.6.9 — supports default gem replacement, avoids Passenger preloader Gem::LoadError.
+RUN gem install bundler -v 2.6.9 --no-document
+
 
 RUN echo '#!/bin/bash\nexec /usr/local/bin/ruby --yjit --yjit-exec-mem-size=64 "$@"' > /usr/local/bin/ruby_yjit && \
     chmod +x /usr/local/bin/ruby_yjit

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=6dc7d515a60b70a27f90e0e8d333df645e37e9a8
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=6b4b282580a8e58f5d61a63f68a87e970e28608c
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -4,6 +4,9 @@
     DocumentRoot /var/www/public
     PassengerAppEnv production
     PassengerRuby /usr/local/bin/ruby
+    # Load Bundler before Ruby preloads default gems so Gemfile.lock pins
+    # (e.g. stringio 3.2.0) win over Ruby-bundled defaults like 3.1.2.
+    PassengerPreloadBundler on
     RewriteEngine On
     
     # Redirect to HTTPS

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -3,12 +3,6 @@ workdir="/var/www"
 export RAILS_ENV=production
 
 setup_env_vars() {
-  #### Apply OHM website overlay patches (if repo mounted)
-  if [ -d /opt/ohm-patches/overlays ]; then
-    echo "Applying OHM website patches from /opt/ohm-patches..."
-    /opt/ohm-patches/scripts/apply.sh "$workdir"
-  fi
-
   #### Setting up the production database
   cat <<EOF > "$workdir/config/database.yml"
 production:

--- a/images/web/start.sh
+++ b/images/web/start.sh
@@ -3,6 +3,12 @@ workdir="/var/www"
 export RAILS_ENV=production
 
 setup_env_vars() {
+  #### Apply OHM website overlay patches (if repo mounted)
+  if [ -d /opt/ohm-patches/overlays ]; then
+    echo "Applying OHM website patches from /opt/ohm-patches..."
+    /opt/ohm-patches/scripts/apply.sh "$workdir"
+  fi
+
   #### Setting up the production database
   cat <<EOF > "$workdir/config/database.yml"
 production:

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -47,7 +47,7 @@ osm-seed:
         accessMode: ReadWriteOnce
         mountPath: /var/lib/postgresql/data
         subPath: postgresql-db
-        AWS_ElasticBlockStore_volumeID : vol-0b83349f8cff18bbe
+        AWS_ElasticBlockStore_volumeID : vol-001f9c55b42984b18
         AWS_ElasticBlockStore_size: 200Gi
       resources:
         enabled: false

--- a/values.staging.template.yaml
+++ b/values.staging.template.yaml
@@ -47,7 +47,7 @@ osm-seed:
         accessMode: ReadWriteOnce
         mountPath: /var/lib/postgresql/data
         subPath: postgresql-db
-        AWS_ElasticBlockStore_volumeID : vol-05ffbd749907e949f
+        AWS_ElasticBlockStore_volumeID : vol-0b83349f8cff18bbe
         AWS_ElasticBlockStore_size: 200Gi
       resources:
         enabled: false


### PR DESCRIPTION
- Ruby 3.3 → 3.4 (builder + runtime).
- Bundler pinned to 2.6.9
- Bundler reinstalled in runtime stage to avoid Passenger Gem::LoadError.
- Base image postgres:17 → postgis/postgis:17-3.5 (PostGIS now required by upstream for area filtering on comments). 

@erictheise quick question — is the upstream merge branch ready to test on staging?

I tested it locally but the map is broken. Let me know when it's ready so we can deploy it on staging. I also need to check the database carefully, since we are switching to a Postgres 17 image that already includes PostGIS.

