### PR TITLE
Increase resource limits for creating full-history and plane dump files

### DIFF
--- a/values.production.template.yaml
+++ b/values.production.template.yaml
@@ -266,11 +266,11 @@ osm-seed:
       enabled: true
       requests:
         enabled: true
-        memory: "6Gi"
+        memory: "8Gi"
         cpu: "3500m"
       limits:
         enabled: false
-        memory: "8Gi"
+        memory: "16Gi"
         cpu: "4000m"
     nodeSelector:
       enabled: false
@@ -300,11 +300,11 @@ osm-seed:
       enabled: true
       requests:
         enabled: true
-        memory: "6Gi"
+        memory: "8Gi"
         cpu: "3500m"
       limits:
         enabled: false
-        memory: "8Gi"
+        memory: "16Gi"
         cpu: "4000m"
     nodeSelector:
       enabled: false


### PR DESCRIPTION
The full-history planet files weren't being published and were already two weeks behind. The job used to run with fewer resources, so I bumped them up and generated the planet file. That's what these changes are for. https://planet.openhistoricalmap.org/?prefix=planet/full-history/

cc. @jeffreyameyer 