### PR TITLE
Fix CORS issues in the web image

### DIFF
--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=0feb1c3337967a3154234d8b7cb1d644094dbc19
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=5f96c54eca693db48ad272b1be32d2a2f90a796b
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \

--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=5f96c54eca693db48ad272b1be32d2a2f90a796b
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=a9a92c5ac3554ffeca489450e020de708c09e436
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -64,8 +64,10 @@
         Header set Access-Control-Allow-Origin "*"
     </Directory>
 
-    # Allow CORS for JSON, PBF, and PNG files for map-style
-    <FilesMatch "\.(json|pbf|png)$">
+    # Allow CORS for PBF and PNG files for map-style.
+    # JSON is excluded so /api/*.json keeps only the header Rails sends, avoiding a
+    # duplicate "*, *" (issue #1377).
+    <FilesMatch "\.(pbf|png)$">
         Header set Access-Control-Allow-Origin "*"
         Header set Access-Control-Allow-Methods "GET, OPTIONS"
         Header set Access-Control-Allow-Headers "Content-Type"

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -17,8 +17,12 @@
     RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
     # Redirect to www openhistoricalmap.org
+    # Skip /map-styles so the non-www host serves the files directly with their
+    # CORS headers. A 301 redirect drops Access-Control-Allow-Origin, which breaks
+    # cross-origin style fetches (e.g. the map-style minimaps).
     RewriteCond %{HTTP_HOST} =openhistoricalmap.org
     RewriteCond %{HTTP_HOST} !^www\. [NC]
+    RewriteCond %{REQUEST_URI} !^/map-styles/
     RewriteRule .* https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
     <Location />

--- a/images/web/config/production.conf
+++ b/images/web/config/production.conf
@@ -17,12 +17,8 @@
     RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
     # Redirect to www openhistoricalmap.org
-    # Skip /map-styles so the non-www host serves the files directly with their
-    # CORS headers. A 301 redirect drops Access-Control-Allow-Origin, which breaks
-    # cross-origin style fetches (e.g. the map-style minimaps).
     RewriteCond %{HTTP_HOST} =openhistoricalmap.org
     RewriteCond %{HTTP_HOST} !^www\. [NC]
-    RewriteCond %{REQUEST_URI} !^/map-styles/
     RewriteRule .* https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
     <Location />


### PR DESCRIPTION
- The CORS rule also matched every .json, including /api/*.json, which already gets its CORS header from Rails. That made the API send the header twice and broke iD running locally, so json is now out of that rule https://github.com/OpenHistoricalMap/issues/issues/1377

- I also bumped the ohm-website gitsha to pull the layer minimap fixes.