### PR TITLE
Build  custom OMH nominatim docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ k3s.sh
 test-preview.sh
 values.k3s.preview.yaml
 tiler-preview.sh
+values.k3s.preview-nominatim.yaml

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -28,4 +28,6 @@ charts:
         valuesPath: osm-seed.planetStats.image
       overpass-api:
         valuesPath: osm-seed.overpassApi.image
+      nominatim:
+        valuesPath: osm-seed.nominatimApi.image
         

--- a/images/nominatim/Dockerfile
+++ b/images/nominatim/Dockerfile
@@ -1,0 +1,29 @@
+FROM mediagis/nominatim:4.5
+
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        cron \
+        wget lua5.3 liblua5.3-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Download required Nominatim country grid
+RUN mkdir -p /app/Nominatim/data && \
+    wget https://www.nominatim.org/data/country_grid.sql.gz -O /app/Nominatim/data/country_osm_grid.sql.gz
+
+COPY docker-entrypoint.sh /app/
+COPY update.sh /app/
+
+# OHM customizations files
+COPY ohm-import.lua /app/ohm-import.lua
+COPY address-levels.json /app/address-levels.json
+
+ENV IMPORT_STYLE=/app/ohm-import.lua
+
+# Ensure scripts are executable
+RUN chmod +x /app/docker-entrypoint.sh /app/update.sh
+
+RUN echo "* * * * * cd /app/Nominatim && bash /app/update.sh >> /var/log/cron.log 2>&1" | crontab -
+
+CMD ["/app/docker-entrypoint.sh"]

--- a/images/nominatim/README.md
+++ b/images/nominatim/README.md
@@ -1,0 +1,26 @@
+# Nominatim (OHM custom image)
+
+Based on `mediagis/nominatim:4.5` and the osm-seed Nominatim image, with OHM
+customizations:
+
+- `ohm-import.lua`: custom import style that extends the standard `extratags`
+  style. It indexes `type=street` relations
+  ([#1308](https://github.com/OpenHistoricalMap/issues/issues/1308)),
+  `type=collection` relations
+  ([#452](https://github.com/OpenHistoricalMap/issues/issues/452)) and
+  `type=route` + `route=railway` relations by name.
+- `address-levels.json`: OHM search and address ranks, baked into the image.
+  This directory is the source of truth for the file; changing it requires an
+  image rebuild.
+
+The import style only applies at import time and during replication updates.
+Street and collection relations that already exist in the database are not
+indexed until they are edited or the database is reimported from a planet
+file.
+
+### Log outputs in the container
+
+```
+/var/log/replication.log
+/var/log/cron.log
+```

--- a/images/nominatim/docker-entrypoint.sh
+++ b/images/nominatim/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+CONFIG_FILE=${PROJECT_DIR}/.env
+
+# Address levels config is baked into the image
+echo NOMINATIM_ADDRESS_LEVEL_CONFIG=/app/address-levels.json >> ${CONFIG_FILE}
+
+if [[ ! -z "$OSMSEED_WEB_API_DOMAIN" ]]; then
+    find /usr/local/lib/nominatim/lib-python/nominatim/ -type f | xargs perl -pi -e "s/www.openstreetmap.org/${OSMSEED_WEB_API_DOMAIN}/g"
+fi
+
+# Cron job is going activate updates even if the script fails once, next time it will start again
+cron & /app/start.sh

--- a/images/nominatim/ohm-import.lua
+++ b/images/nominatim/ohm-import.lua
@@ -1,0 +1,27 @@
+-- OHM import style, extends the standard 'extratags' style.
+-- Indexes street and collection relations by name:
+-- https://github.com/OpenHistoricalMap/issues/issues/1308
+-- https://github.com/OpenHistoricalMap/issues/issues/452
+
+local flex = require('import-extratags')
+
+flex.RELATION_TYPES['street'] = flex.relation_as_multiline
+flex.RELATION_TYPES['collection'] = flex.relation_as_multiline
+flex.RELATION_TYPES['route'] = flex.relation_as_multiline
+
+-- Street and railway route relations carry only identity tags (type, name,
+-- dates), so give them a generic main tag to get the same ranks as named
+-- highway/railway ways.
+local original_process_relation = osm2pgsql.process_relation
+
+function osm2pgsql.process_relation(object)
+    local tags = object.tags
+    if tags.type == 'street' and tags.highway == nil then
+        tags.highway = 'road'
+    elseif tags.type == 'route' and tags.route == 'railway' and tags.railway == nil then
+        tags.railway = 'rail'
+    end
+    original_process_relation(object)
+end
+
+return flex

--- a/images/nominatim/update.sh
+++ b/images/nominatim/update.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+# Because of crashing updates, we wrote this small script to update every minute the Nominatim api
+LOCAL_API=http://localhost:8080
+echo "Updating nominatim api...."
+wget -q --spider $LOCAL_API
+if [ ! $? -ne 0 ]; then
+    sudo -u nominatim nominatim replication --project-dir /nominatim --catch-up >>/var/log/replication.log
+fi

--- a/ohm/values.yaml
+++ b/ohm/values.yaml
@@ -31,6 +31,10 @@ osm-seed:
     image:
       name: chartpress_replace_me
       tag: chartpress_replace_me
+  nominatimApi:
+    image:
+      name: chartpress_replace_me
+      tag: chartpress_replace_me
   osmxAdiffBuilder:
     image:
       name: chartpress_replace_me

--- a/values.k3s.production.template.yaml
+++ b/values.k3s.production.template.yaml
@@ -332,8 +332,6 @@ osm-seed:
     serviceAnnotations:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
     replicaCount: 1
-    # Give the initial planet import time to finish (5h) before the liveness
-    # probe starts checking the API.
     livenessProbe:
       httpGet:
         path: /status
@@ -344,7 +342,7 @@ osm-seed:
       failureThreshold: 6
     env:
       NOMINATIM_API_ENDPOINT: nominatim.openhistoricalmap.org
-      PBF_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260408_0307.osm.pbf
+      PBF_URL: https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260714_0001.osm.pbf
       REPLICATION_URL: http://planet.openhistoricalmap.org.s3.amazonaws.com/replication/minute
       REPLICATION_UPDATE_INTERVAL: 60
       REPLICATION_RECHECK_INTERVAL: 30
@@ -368,7 +366,7 @@ osm-seed:
       mountPath: /var/lib/postgresql/16/main
       subPath: nominatim-pgdata
       staticHostPath: true
-      localVolumeHostPath: /mnt/nominatim-db-data
+      localVolumeHostPath: /mnt/nominatim-db-data-v2
     nodeSelector:
       enabled: false
     nodeAffinity:

--- a/values.k3s.production.template.yaml
+++ b/values.k3s.production.template.yaml
@@ -332,6 +332,16 @@ osm-seed:
     serviceAnnotations:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
     replicaCount: 1
+    # Give the initial planet import time to finish (5h) before the liveness
+    # probe starts checking the API.
+    livenessProbe:
+      httpGet:
+        path: /status
+        port: 8080
+      initialDelaySeconds: 18000
+      periodSeconds: 60
+      timeoutSeconds: 30
+      failureThreshold: 6
     env:
       NOMINATIM_API_ENDPOINT: nominatim.openhistoricalmap.org
       PBF_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260408_0307.osm.pbf
@@ -346,9 +356,8 @@ osm-seed:
       IMPORT_TIGER_ADDRESSES: false
       PGDATA: /var/lib/postgresql/16/main
       OSMSEED_WEB_API_DOMAIN: www.${OHM_DOMAIN}
-      NOMINATIM_ADDRESS_LEVEL_CONFIG_URL: https://raw.githubusercontent.com/OpenHistoricalMap/nominatim-ui/master/address-levels.json
       UPDATE_MODE: continuous
-      IMPORT_STYLE: extratags
+      IMPORT_STYLE: /app/ohm-import.lua
       EXTRA_TAGS: "start_date,start_date:edtf,end_date,end_date:edtf"
       NOMINATIM_PASSWORD: "{{PRODUCTION_NOMINATIM_PG_PASSWORD}}"
     resources:

--- a/values.k3s.staging.template.yaml
+++ b/values.k3s.staging.template.yaml
@@ -312,15 +312,10 @@ osm-seed:
     enabled: true
     ingress:
       enabled: false
-    # image:
-    #   name: developmentseed/osmseed-nominatim
-    #   tag: 1.0.0-dev.hb293d54
     priorityClass: medium-priority
     serviceAnnotations:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
     replicaCount: 1
-    # Give the initial planet import time to finish (5h) before the liveness
-    # probe starts checking the API.
     livenessProbe:
       httpGet:
         path: /status
@@ -331,7 +326,7 @@ osm-seed:
       failureThreshold: 6
     env:
       NOMINATIM_API_ENDPOINT: nominatim.ohmstaging.org
-      PBF_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260408_0307.osm.pbf
+      PBF_URL: https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260714_0001.osm.pbf
       REPLICATION_URL: http://planet.openhistoricalmap.org.s3.amazonaws.com/replication/minute
       REPLICATION_UPDATE_INTERVAL: 60
       REPLICATION_RECHECK_INTERVAL: 30
@@ -355,7 +350,7 @@ osm-seed:
       mountPath: /var/lib/postgresql/16/main
       subPath: nominatim-pgdata
       staticHostPath: true
-      localVolumeHostPath: /mnt/nominatim-db-data
+      localVolumeHostPath: /mnt/nominatim-db-data-v2
     nodeSelector:
       enabled: false
     nodeAffinity:

--- a/values.k3s.staging.template.yaml
+++ b/values.k3s.staging.template.yaml
@@ -319,6 +319,16 @@ osm-seed:
     serviceAnnotations:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
     replicaCount: 1
+    # Give the initial planet import time to finish (5h) before the liveness
+    # probe starts checking the API.
+    livenessProbe:
+      httpGet:
+        path: /status
+        port: 8080
+      initialDelaySeconds: 18000
+      periodSeconds: 60
+      timeoutSeconds: 30
+      failureThreshold: 6
     env:
       NOMINATIM_API_ENDPOINT: nominatim.ohmstaging.org
       PBF_URL: http://s3.amazonaws.com/planet.openhistoricalmap.org/planet/planet-260408_0307.osm.pbf
@@ -333,9 +343,8 @@ osm-seed:
       IMPORT_TIGER_ADDRESSES: false
       PGDATA: /var/lib/postgresql/16/main
       OSMSEED_WEB_API_DOMAIN: www.${OHM_DOMAIN}
-      NOMINATIM_ADDRESS_LEVEL_CONFIG_URL: https://raw.githubusercontent.com/OpenHistoricalMap/nominatim-ui/master/address-levels.json
       UPDATE_MODE: continuous
-      IMPORT_STYLE: extratags
+      IMPORT_STYLE: /app/ohm-import.lua
       EXTRA_TAGS: "start_date,start_date:edtf,end_date,end_date:edtf"
       NOMINATIM_PASSWORD: "{{STAGING_NOMINATIM_PG_PASSWORD}}"
     resources:


### PR DESCRIPTION
To solve some Nominatim issues, we needed a custom Nominatim Docker image for OHM, so we can use a custom import style - ohm-import.lua:

- https://github.com/OpenHistoricalMap/issues/issues/452 — collection relations
  were not indexed, so places like Hadrian's Wall returned no results.

- https://github.com/OpenHistoricalMap/issues/issues/1308 — street relations
  were not searchable by name.
