### PR TITLE
Update ohm-website gitsha so Nominatim results jump the slider to start_date

### DIFF
--- a/images/web/Dockerfile
+++ b/images/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download OHM Website using gitsha, faster than cloning
-ENV OPENHISTORICALMAP_WEBSITE_GITSHA=70da7499d96caaeb45d58860e64856feda2ea551
+ENV OPENHISTORICALMAP_WEBSITE_GITSHA=8239af4a2fb1713a5f453919f3d890687516107c
 ENV OHM_WEBSITE_URL=https://github.com/OpenHistoricalMap/ohm-website/archive/${OPENHISTORICALMAP_WEBSITE_GITSHA}.zip
 RUN rm -rf $workdir/* && curl -fsSL $OHM_WEBSITE_URL -o /tmp/ohm-website.zip && \
     unzip /tmp/ohm-website.zip -d /tmp && \


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/196
Nominatim search results now move the time slider to the feature's period.