### PR TITLE
Add religion attribute on religious features

### DIFF
--- a/images/tiler-imposm/queries/ohm_mviews/amenity.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/amenity.sql
@@ -5,7 +5,10 @@ SELECT create_points_mview(
     'osm_amenity_points',
     'mv_amenity_points',
     'id, source, osm_id',
-    NULL,
+    ARRAY[
+        'NULLIF(tags->''religion'', '''') AS religion',
+        'NULLIF(tags->''denomination'', '''') AS denomination'
+    ],
     NULL
 );
 
@@ -21,7 +24,7 @@ SELECT create_areas_mview(
     5000,
     'id, osm_id, type',
     NULL,
-    NULL,
+    'NULLIF(tags->''religion'', '''') AS religion, NULLIF(tags->''denomination'', '''') AS denomination',
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -42,7 +45,7 @@ SELECT create_areas_mview(
     0,
     'id, osm_id, type',
     NULL,
-    NULL,
+    'NULLIF(tags->''religion'', '''') AS religion, NULLIF(tags->''denomination'', '''') AS denomination',
     NULL
 );
 SELECT create_points_centroids_mview(

--- a/images/tiler-imposm/queries/ohm_mviews/landuse.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/landuse.sql
@@ -7,7 +7,7 @@
 DROP MATERIALIZED VIEW IF EXISTS mv_landuse_areas_z16_20 CASCADE;
 
 
-SELECT create_areas_mview( 'osm_landuse_areas', 'mv_landuse_areas_z16_20', 0, 0, 'id, osm_id, type', 'NOT (type = ''water'' AND class = ''natural'')', NULL, NULL);
+SELECT create_areas_mview( 'osm_landuse_areas', 'mv_landuse_areas_z16_20', 0, 0, 'id, osm_id, type', 'NOT (type = ''water'' AND class = ''natural'')', 'NULLIF(tags->''religion'', '''') AS religion, NULLIF(tags->''denomination'', '''') AS denomination', NULL);
 SELECT create_area_mview_from_mview('mv_landuse_areas_z16_20', 'mv_landuse_areas_z13_15', 5, 10000, NULL);
 SELECT create_area_mview_from_mview('mv_landuse_areas_z13_15', 'mv_landuse_areas_z10_12', 20, 50000, NULL);
 SELECT create_area_mview_from_mview('mv_landuse_areas_z10_12', 'mv_landuse_areas_z8_9', 100, 1000000, NULL);
@@ -19,7 +19,7 @@ SELECT create_area_mview_from_mview('mv_landuse_areas_z8_9', 'mv_landuse_areas_z
 -- Create points materialized view to add laater with centroids
 -- Exclude natrual=water https://github.com/OpenHistoricalMap/issues/issues/1197
 -- ============================================================================
-SELECT create_points_mview('osm_landuse_points', 'mv_landuse_points', 'id, source, osm_id', NULL, NULL);
+SELECT create_points_mview('osm_landuse_points', 'mv_landuse_points', 'id, source, osm_id', ARRAY['NULLIF(tags->''religion'', '''') AS religion', 'NULLIF(tags->''denomination'', '''') AS denomination'], NULL);
 -- Create points centroids materialized views, add points  only for higher zoom levels
 SELECT create_points_centroids_mview('mv_landuse_areas_z16_20','mv_landuse_points_centroids_z16_20','mv_landuse_points');
 SELECT create_points_centroids_mview( 'mv_landuse_areas_z13_15', 'mv_landuse_points_centroids_z13_15', 'mv_landuse_points');

--- a/images/tiler-imposm/queries/ohm_mviews/others.sql
+++ b/images/tiler-imposm/queries/ohm_mviews/others.sql
@@ -13,7 +13,7 @@ SELECT create_areas_mview(
     1000000,
     'id, osm_id, type',
     NULL,
-    NULL,
+    'NULLIF(tags->''religion'', '''') AS religion, NULLIF(tags->''denomination'', '''') AS denomination',
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -32,7 +32,7 @@ SELECT create_areas_mview(
     50000,
     'id, osm_id, type',
     NULL,
-    NULL,
+    'NULLIF(tags->''religion'', '''') AS religion, NULLIF(tags->''denomination'', '''') AS denomination',
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -50,7 +50,10 @@ SELECT create_points_mview(
     'osm_other_points',
     'mv_other_points',
     'id, source, osm_id',
-    NULL,
+    ARRAY[
+        'NULLIF(tags->''religion'', '''') AS religion',
+        'NULLIF(tags->''denomination'', '''') AS denomination'
+    ],
     NULL
 );
 
@@ -65,7 +68,7 @@ SELECT create_areas_mview(
     5000,
     'id, osm_id, type',
     NULL,
-    NULL,
+    'NULLIF(tags->''religion'', '''') AS religion, NULLIF(tags->''denomination'', '''') AS denomination',
     NULL
 );
 SELECT create_points_centroids_mview(
@@ -87,7 +90,7 @@ SELECT create_areas_mview(
     0,
     'id, osm_id, type',
     NULL,
-    NULL,
+    'NULLIF(tags->''religion'', '''') AS religion, NULLIF(tags->''denomination'', '''') AS denomination',
     NULL
 );
 SELECT create_points_centroids_mview(


### PR DESCRIPTION
From: https://github.com/OpenHistoricalMap/issues/issues/1405
Religion and denomination attributes are now exposed in staging,  The amenity, landuse, and other layers include religion and denomination columns.

Some numbers from the staging database:

- Amenity features with religion: christian 7,163 · jewish 221 · muslim 182 · buddhist 135 · shinto 127 · pagan 114 · taoist 18 · hindu 13
- Landuse areas with religion (cemeteries, religious landuse): 519
- Shop/other points with religion: 74