### PR TITLE
Show branch and commit message in deploy run names

### DIFF
--- a/.github/workflows/deploy-eks.yaml
+++ b/.github/workflows/deploy-eks.yaml
@@ -1,5 +1,12 @@
 name: Deploy EKS
 
+# Show the source branch and commit message in the run list, so it is easy
+# to tell which push each deploy belongs to.
+run-name: >-
+  ${{ github.event_name == 'workflow_run'
+      && format('Deploy EKS — {0}: {1}', github.event.workflow_run.head_branch, github.event.workflow_run.head_commit.message)
+      || format('Deploy EKS — manual: {0}', inputs.ref) }}
+
 # Deploys the ohm/ chart to AWS EKS.
 #
 # Triggers:

--- a/.github/workflows/deploy-k3s.yaml
+++ b/.github/workflows/deploy-k3s.yaml
@@ -1,5 +1,12 @@
 name: Deploy k3s
 
+# Show the source branch and commit message in the run list, so it is easy
+# to tell which push each deploy belongs to.
+run-name: >-
+  ${{ github.event_name == 'workflow_run'
+      && format('Deploy k3s — {0}: {1}', github.event.workflow_run.head_branch, github.event.workflow_run.head_commit.message)
+      || format('Deploy k3s — manual: {0}', inputs.ref) }}
+
 on:
   # Deploy only after "Build images (chartpress)" finishes, never on push
   # directly. A push runs build-images, which triggers this on success. That


### PR DESCRIPTION
Deploy runs only showed the workflow name, so it was hard to tell which push they came from. This adds a run-name with the branch and commit message to Deploy k3s and Deploy EKS.